### PR TITLE
fix(grid): do not use the last field's style to draw field blanks #WIK-16973

### DIFF
--- a/packages/grid/src/renderer/creations/create-cells.ts
+++ b/packages/grid/src/renderer/creations/create-cells.ts
@@ -58,6 +58,7 @@ export const createCells = (config: AITableCellsDrawerConfig) => {
             switch (type) {
                 case AITableRowType.add: {
                     const isHoverRow = isHover && targetName === AI_TABLE_ROW_ADD_BUTTON;
+                    const isCheckedRow = aiTable.selection().selectedRecords.has(row._id);
                     addRowLayout.init({
                         x,
                         y,
@@ -69,7 +70,8 @@ export const createCells = (config: AITableCellsDrawerConfig) => {
                         containerWidth: coordinate.containerWidth
                     });
                     addRowLayout.render({
-                        isHoverRow
+                        isHoverRow,
+                        isCheckedRow
                     });
                     break;
                 }

--- a/packages/grid/src/renderer/drawers/add-row-layout-drawer.ts
+++ b/packages/grid/src/renderer/drawers/add-row-layout-drawer.ts
@@ -11,8 +11,8 @@ import { AITableCell } from '../../types';
 import { Layout } from './layout-drawer';
 
 export class AddRowLayout extends Layout {
-    override renderAddFieldBlank({ isHoverRow }: Pick<AITableCell, 'isHoverRow'>) {
-        super.renderAddFieldBlank({ isHoverRow });
+    override renderAddFieldBlank({ isHoverRow, isCheckedRow }: Pick<AITableCell, 'isHoverRow' | 'isCheckedRow'>) {
+        super.renderAddFieldBlank({ isHoverRow, isCheckedRow });
         const rowHeight = this.rowHeight;
         const defaultWidth = AI_TABLE_FIELD_ADD_BUTTON_WIDTH;
         const width = this.containerWidth - this.x < defaultWidth ? defaultWidth : this.containerWidth - this.x;
@@ -76,7 +76,7 @@ export class AddRowLayout extends Layout {
         });
     }
 
-    private renderLastCell({ isHoverRow }: Pick<AITableCell, 'isHoverRow'>) {
+    private renderLastCell({ isHoverRow, isCheckedRow }: Pick<AITableCell, 'isHoverRow' | 'isCheckedRow'>) {
         if (!this.isLast) return;
         const width = this.columnWidth;
         if (!this.isFirst) {
@@ -85,7 +85,7 @@ export class AddRowLayout extends Layout {
                 isHoverRow
             });
         }
-        this.renderAddFieldBlank({ isHoverRow });
+        this.renderAddFieldBlank({ isHoverRow, isCheckedRow });
     }
 
     private renderCommonCell({ isHoverRow }: Pick<AITableCell, 'isHoverRow'>) {
@@ -96,7 +96,7 @@ export class AddRowLayout extends Layout {
         });
     }
 
-    render({ isHoverRow }: Pick<AITableCell, 'isHoverRow'>) {
+    render({ isHoverRow, isCheckedRow }: Pick<AITableCell, 'isHoverRow' | 'isCheckedRow'>) {
         this.renderFirstCell({
             isHoverRow
         });
@@ -104,7 +104,8 @@ export class AddRowLayout extends Layout {
             isHoverRow
         });
         this.renderLastCell({
-            isHoverRow
+            isHoverRow,
+            isCheckedRow
         });
     }
 }

--- a/packages/grid/src/renderer/drawers/layout-drawer.ts
+++ b/packages/grid/src/renderer/drawers/layout-drawer.ts
@@ -46,9 +46,10 @@ export class Layout extends Drawer {
         return this.columnIndex === this.columnCount - 1;
     }
 
-    protected renderAddFieldBlank({ style, isHoverRow }: Pick<AITableCell, 'isHoverRow' | 'style'>) {
+    protected renderAddFieldBlank({ style, isHoverRow, isCheckedRow }: Pick<AITableCell, 'isHoverRow' | 'isCheckedRow' | 'style'>) {
         const rowHeight = this.rowHeight;
-        const fill = style?.fill || (isHoverRow ? this.colors.gray80 : this.colors.transparent);
+        const fill =
+            style?.fill || (isCheckedRow ? this.colors.itemActiveBgColor : isHoverRow ? this.colors.gray80 : this.colors.transparent);
         const addFieldBlankX = this.x + this.columnWidth + AI_TABLE_OFFSET;
         this.rect({
             x: addFieldBlankX,

--- a/packages/grid/src/renderer/drawers/record-row-layout-drawer.ts
+++ b/packages/grid/src/renderer/drawers/record-row-layout-drawer.ts
@@ -83,7 +83,7 @@ export class RecordRowLayout extends Layout {
         });
 
         // 延伸到 FIELD_ADD_BUTTON
-        super.renderAddFieldBlank({ style, isHoverRow });
+        super.renderAddFieldBlank({ isHoverRow });
         const rowHeight = this.rowHeight;
         const startX = this.x + this.columnWidth;
         const lineWidth =

--- a/packages/grid/src/renderer/drawers/record-row-layout-drawer.ts
+++ b/packages/grid/src/renderer/drawers/record-row-layout-drawer.ts
@@ -66,7 +66,7 @@ export class RecordRowLayout extends Layout {
     }
 
     // 尾列
-    private renderLastCell({ style, isHoverRow }: Pick<AITableCell, 'style' | 'isHoverRow'>) {
+    private renderLastCell({ style, isHoverRow, isCheckedRow }: Pick<AITableCell, 'style' | 'isHoverRow' | 'isCheckedRow'>) {
         if (!this.isLast || this.isFirst) return;
 
         const { fill, stroke } = style;
@@ -83,7 +83,7 @@ export class RecordRowLayout extends Layout {
         });
 
         // 延伸到 FIELD_ADD_BUTTON
-        super.renderAddFieldBlank({ isHoverRow });
+        super.renderAddFieldBlank({ isHoverRow, isCheckedRow });
         const rowHeight = this.rowHeight;
         const startX = this.x + this.columnWidth;
         const lineWidth =
@@ -118,7 +118,7 @@ export class RecordRowLayout extends Layout {
         const { row, style, isCheckedRow, isHoverRow } = config;
         this.renderFirstCell({ row, style, isCheckedRow, isHoverRow });
         this.renderCommonCell({ style });
-        this.renderLastCell({ style, isHoverRow });
+        this.renderLastCell({ style, isCheckedRow, isHoverRow });
     }
 }
 


### PR DESCRIPTION
Before Repair：
<img width="970" alt="image" src="https://github.com/user-attachments/assets/019cfb55-5148-43e9-8356-1ae9142bebf4" />
After Repair：
<img width="969" alt="image" src="https://github.com/user-attachments/assets/44447a45-879c-4def-ba92-59f754964e6e" />
