### PR TITLE
feat(grid): support activate status when a single cell contextmenu is opened #WIK-16969

### DIFF
--- a/packages/grid/src/components/context-menu/context-menu.component.html
+++ b/packages/grid/src/components/context-menu/context-menu.component.html
@@ -4,7 +4,7 @@
         <a
             thyDropdownMenuItem
             href="javascript:;"
-            [ngClass]="{ 'remove-record': !disabled }"
+            [ngClass]="{ 'ai-table-prohibit-clear-selection remove-record': !disabled }"
             (click)="execute(menu)"
             [thyDisabled]="disabled"
         >

--- a/packages/grid/src/components/context-menu/context-menu.component.ts
+++ b/packages/grid/src/components/context-menu/context-menu.component.ts
@@ -42,8 +42,7 @@ export class AITableContextMenu extends ThyDropdownAbstractMenu {
 
     execute(menu: AITableContextMenuItem) {
         if ((menu.disabled && !menu.disabled(this.aiTable(), this.targetName(), this.position())) || !menu.disabled) {
-            menu.exec && menu.exec(this.aiTable(), this.targetName(), this.position());
-            this.aiTableGridSelectionService.clearSelection();
+            menu.exec && menu.exec(this.aiTable(), this.targetName(), this.position(), this.aiTableGridSelectionService);
         }
     }
 }

--- a/packages/grid/src/components/context-menu/context-menu.component.ts
+++ b/packages/grid/src/components/context-menu/context-menu.component.ts
@@ -1,5 +1,5 @@
 import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import {
     ThyDropdownAbstractMenu,
     ThyDropdownMenuComponent,
@@ -10,6 +10,7 @@ import {
 import { ThyIcon } from 'ngx-tethys/icon';
 import { AITable } from '../../core';
 import { AITableContextMenuItem } from '../../types';
+import { AITableGridSelectionService } from '../../services/selection.service';
 
 @Component({
     selector: 'ai-table-context-menu',
@@ -29,6 +30,8 @@ import { AITableContextMenuItem } from '../../types';
     ]
 })
 export class AITableContextMenu extends ThyDropdownAbstractMenu {
+    private aiTableGridSelectionService = inject(AITableGridSelectionService);
+
     aiTable = input.required<AITable>();
 
     menuItems = input.required<AITableContextMenuItem[]>();
@@ -40,6 +43,7 @@ export class AITableContextMenu extends ThyDropdownAbstractMenu {
     execute(menu: AITableContextMenuItem) {
         if ((menu.disabled && !menu.disabled(this.aiTable(), this.targetName(), this.position())) || !menu.disabled) {
             menu.exec && menu.exec(this.aiTable(), this.targetName(), this.position());
+            this.aiTableGridSelectionService.clearSelection();
         }
     }
 }

--- a/packages/grid/src/components/index.ts
+++ b/packages/grid/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './cell-editors/select/select-editor.component';
 export * from './cell-editors/text/text-editor.component';
 export * from './cell-views/select/option.component';
 export * from './field-property-editor/field-property-editor.component';
+export * from './context-menu/context-menu.component';

--- a/packages/grid/src/constants/table.ts
+++ b/packages/grid/src/constants/table.ts
@@ -23,6 +23,8 @@ export const AI_TABLE_FIELD_ADD_BUTTON_WIDTH = 100; // 添加列宽度
 export const AI_TABLE_FIELD_HEAD_ICON_GAP_SIZE = 8; // 字段表列头图标的间距
 export const AI_TABLE_FIELD_HEAD_MORE = 'AI_TABLE_FIELD_HEAD_MORE'; // 更多图标名称
 
+export const AI_TABLE_PROHIBIT_CLEAR_SELECTION_CLASS = '.ai-table-prohibit-clear-selection';
+
 export const AI_TABLE_ICON_COMMON_SIZE = 16; // 表格图标的通用尺寸
 export const AI_TABLE_CELL = 'AI_TABLE_CELL'; // 单元格标识
 // 因为 dom 的边距 12 是不包含 边框的，所以加上边框 2px  才能跟 编辑里面的内容对其；

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -137,7 +137,6 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         afterNextRender(() => {
             this.setContainerRect();
             this.bindGlobalMousedown();
-            this.bindGlobalContextmenu();
             this.containerResizeListener();
             this.bindWheel();
         });
@@ -416,12 +415,6 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
                 this.aiTableGridSelectionService.clearSelection();
                 this.closeContextMenu();
             });
-    }
-
-    private bindGlobalContextmenu() {
-        fromEvent<MouseEvent>(document, 'contextmenu', { passive: false }).subscribe((e) => {
-            e.preventDefault();
-        });
     }
 
     private resetScrolling = () => {

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -25,6 +25,7 @@ import {
     AI_TABLE_FIELD_HEAD_HEIGHT,
     AI_TABLE_FIELD_HEAD_MORE,
     AI_TABLE_FIELD_HEAD_SELECT_CHECKBOX,
+    AI_TABLE_PROHIBIT_CLEAR_SELECTION_CLASS,
     AI_TABLE_ROW_ADD_BUTTON,
     AI_TABLE_ROW_HEAD_WIDTH,
     AI_TABLE_ROW_SELECT_CHECKBOX,
@@ -407,7 +408,7 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
                     (e) =>
                         e.target instanceof Element &&
                         !this.containerElement().contains(e.target) &&
-                        !(e.target.closest('.remove-record') && this.aiTable.selection().selectedRecords.size > 0)
+                        !(e.target.closest(AI_TABLE_PROHIBIT_CLEAR_SELECTION_CLASS) && this.aiTable.selection().selectedRecords.size > 0)
                 ),
                 takeUntilDestroyed(this.destroyRef)
             )

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -43,8 +43,6 @@ import { AITableGridSelectionService } from './services/selection.service';
 import { AITableMouseDownType, AITableRendererConfig, ScrollActionOptions } from './types';
 import { buildGridLinearRows, getColumnIndicesMap, getDetailByTargetName, handleMouseStyle, isWindows } from './utils';
 import { getMousePosition } from './utils/position';
-import { ThyPopoverRef } from 'ngx-tethys/popover';
-import { AITableContextMenu } from './components';
 
 @Component({
     selector: 'ai-table-grid',

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -195,7 +195,10 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         const _targetName = e.event.target.name();
 
         const { targetName, fieldId, recordId } = getDetailByTargetName(_targetName);
-        if (mouseEvent.button === AITableMouseDownType.Right && recordId && fieldId) return;
+        const hasCheckedRecords = !!this.aiTable.selection().selectedRecords.size;
+        if (mouseEvent.button === AITableMouseDownType.Right && recordId && fieldId && hasCheckedRecords) {
+            return;
+        }
 
         switch (targetName) {
             case AI_TABLE_FIELD_HEAD:

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -195,8 +195,12 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         const _targetName = e.event.target.name();
 
         const { targetName, fieldId, recordId } = getDetailByTargetName(_targetName);
-        const hasCheckedRecords = !!this.aiTable.selection().selectedRecords.size;
-        if (mouseEvent.button === AITableMouseDownType.Right && recordId && fieldId && hasCheckedRecords) {
+        if (
+            mouseEvent.button === AITableMouseDownType.Right &&
+            recordId &&
+            fieldId &&
+            this.aiTable.selection().selectedRecords.has(recordId)
+        ) {
             return;
         }
 

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -58,8 +58,6 @@ import { AITableContextMenu } from './components';
     providers: [AITableGridEventService, AITableGridFieldService, AITableGridSelectionService]
 })
 export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
-    private contextmenuRef!: ThyPopoverRef<AITableContextMenu> | null;
-
     private viewContainerRef = inject(ViewContainerRef);
 
     timer!: number | null;

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -255,7 +255,7 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
             return;
         }
 
-        this.contextmenuRef = this.aiTableGridEventService.openContextMenu(this.aiTable, {
+        this.aiTableGridEventService.openContextMenu(this.aiTable, {
             origin: this.containerElement(),
             menuItems,
             position,
@@ -413,7 +413,6 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
             )
             .subscribe(() => {
                 this.aiTableGridSelectionService.clearSelection();
-                this.closeContextMenu();
             });
     }
 
@@ -508,13 +507,6 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
             if (editingCell && MOUSEOVER_EDIT_TYPE.includes(this.aiTable.fieldsMap()[editingCell.fieldId].type)) {
                 this.aiTableGridEventService.closeCellEditor();
             }
-        }
-    }
-
-    private closeContextMenu() {
-        if (this.contextmenuRef) {
-            this.contextmenuRef.close();
-            this.contextmenuRef = null;
         }
     }
 }

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -399,7 +399,12 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
     private bindGlobalMousedown() {
         fromEvent<MouseEvent>(document, 'mousedown', { passive: true })
             .pipe(
-                filter((e) => e.target instanceof Element && !this.containerElement().contains(e.target)),
+                filter(
+                    (e) =>
+                        e.target instanceof Element &&
+                        !this.containerElement().contains(e.target) &&
+                        !(e.target.closest('.remove-record') && this.aiTable.selection().selectedRecords.size > 0)
+                ),
                 takeUntilDestroyed(this.destroyRef)
             )
             .subscribe(() => {

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -5,11 +5,13 @@ import {
     computed,
     effect,
     ElementRef,
+    inject,
     OnDestroy,
     OnInit,
     Signal,
     signal,
-    viewChild
+    viewChild,
+    ViewContainerRef
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { filter, fromEvent } from 'rxjs';
@@ -56,6 +58,8 @@ import { AITableContextMenu } from './components';
 })
 export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
     private contextmenuRef!: ThyPopoverRef<AITableContextMenu> | null;
+
+    private viewContainerRef = inject(ViewContainerRef);
 
     timer!: number | null;
 
@@ -256,7 +260,8 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
             origin: this.containerElement(),
             menuItems,
             position,
-            targetName
+            targetName,
+            viewContainerRef: this.viewContainerRef
         });
     }
 

--- a/packages/grid/src/renderer/components/hover-row-heads.component.ts
+++ b/packages/grid/src/renderer/components/hover-row-heads.component.ts
@@ -71,7 +71,7 @@ export class AITableHoverRowHeads {
             }
 
             let isHoverRow;
-            if (pointRowIndex > -1) {
+            if (pointRowIndex > -1 && !!context.linearRows().length && pointRowIndex < context.linearRows().length) {
                 const { type: pointRowType, _id: pointRecordId } = context.linearRows()[pointRowIndex];
                 isHoverRow = recordId === pointRecordId && pointRowType === AITableRowType.record && targetName !== AI_TABLE_FIELD_HEAD;
             }

--- a/packages/grid/src/services/event.service.ts
+++ b/packages/grid/src/services/event.service.ts
@@ -230,12 +230,13 @@ export class AITableGridEventService {
     }
 
     openContextMenu(aiTable: AITable, options: AITableContextMenuOptions) {
-        const { origin, position, menuItems, targetName } = options;
+        const { origin, position, menuItems, targetName, viewContainerRef } = options;
         const ref = this.thyPopover.open(AITableContextMenu, {
             origin: origin as HTMLElement,
             originPosition: position,
             placement: 'bottomLeft',
             insideClosable: true,
+            viewContainerRef,
             initialState: {
                 aiTable,
                 menuItems,

--- a/packages/grid/src/types/row.ts
+++ b/packages/grid/src/types/row.ts
@@ -1,4 +1,4 @@
-import { ElementRef } from '@angular/core';
+import { ElementRef, ViewContainerRef } from '@angular/core';
 import { AITable, Coordinate } from '../core';
 
 export enum AITableRowType {
@@ -47,4 +47,5 @@ export interface AITableContextMenuOptions {
     position: { x: number; y: number };
     menuItems: AITableContextMenuItem[];
     targetName: string;
+    viewContainerRef: ViewContainerRef;
 }

--- a/packages/grid/src/types/row.ts
+++ b/packages/grid/src/types/row.ts
@@ -1,5 +1,6 @@
 import { ElementRef, ViewContainerRef } from '@angular/core';
 import { AITable, Coordinate } from '../core';
+import { AITableGridSelectionService } from '../services/selection.service';
 
 export enum AITableRowType {
     add = 'add',
@@ -37,7 +38,12 @@ export interface AITableContextMenuItem {
     type: string;
     name?: string;
     icon?: string;
-    exec?: (aiTable: AITable, targetName: string, position: { x: number; y: number }) => void;
+    exec?: (
+        aiTable: AITable,
+        targetName: string,
+        position: { x: number; y: number },
+        aiTableGridSelectionService: AITableGridSelectionService
+    ) => void;
     hidden?: (aiTable: AITable, targetName: string, position: { x: number; y: number }) => boolean;
     disabled?: (aiTable: AITable, targetName: string, position: { x: number; y: number }) => boolean;
 }

--- a/packages/state/src/constants/context-menu-item.ts
+++ b/packages/state/src/constants/context-menu-item.ts
@@ -1,4 +1,4 @@
-import { AITable, AITableContextMenuItem, getDetailByTargetName } from '@ai-table/grid';
+import { AITable, AITableContextMenuItem, AITableGridSelectionService, getDetailByTargetName } from '@ai-table/grid';
 import { Actions } from '../action';
 import { AIViewTable } from '../types';
 
@@ -6,7 +6,12 @@ export const RemoveRecordsItem: AITableContextMenuItem = {
     type: 'removeRecords',
     name: '删除行',
     icon: 'trash',
-    exec: (aiTable: AITable, targetName: string) => {
+    exec: (
+        aiTable: AITable,
+        targetName: string,
+        position: { x: number; y: number },
+        aiTableGridSelectionService: AITableGridSelectionService
+    ) => {
         let selectedRecordIds = [...aiTable.selection().selectedRecords.keys()];
         if (!selectedRecordIds.length) {
             const recordId = getDetailByTargetName(targetName).recordId as string;
@@ -16,5 +21,7 @@ export const RemoveRecordsItem: AITableContextMenuItem = {
         selectedRecordIds.forEach((id: string) => {
             Actions.removeRecord(aiTable as AIViewTable, [id]);
         });
+
+        aiTableGridSelectionService.clearSelection();
     }
 };


### PR DESCRIPTION
1. 有选中行的情况下，右键单元格，不取消行的选中。
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/5eb25c5a-2931-423b-a6dd-fe9210762080" />

2. 没有选中行的情况下，右键单元格，激活状态样式和左击单元格一致。
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/e208a670-802b-4c7a-809a-68ed23ed05d2" />

3. 有选中行的情况下，右键的单元格如果不是选中行的单元格，触发单元格的右键菜单
5. 在执行批量删除之前，不要清空选中