### PR TITLE
fix(grid): should create correct default name and show correct type after selecting multiple member  field

### DIFF
--- a/packages/grid/src/core/utils/field.ts
+++ b/packages/grid/src/core/utils/field.ts
@@ -47,7 +47,7 @@ export function getFieldOptionByField(field: Partial<AITableField>) {
 export function isSameFieldOption(fieldOption: AITableFieldOption, field: Partial<AITableField>): boolean {
     return (
         fieldOption.type === field.type &&
-        (fieldOption.type === AITableFieldType.select
+        (fieldOption.type === AITableFieldType.select || fieldOption.type === AITableFieldType.member
             ? !!(fieldOption.settings as IsMultiple)?.is_multiple === !!(field.settings as IsMultiple)?.is_multiple
             : true)
     );


### PR DESCRIPTION
before:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/665695bb-9b73-4835-b0e9-9b9058824091" />


after:
<img width="615" alt="image" src="https://github.com/user-attachments/assets/173c34e4-10e6-447e-a8e7-fd46d4b3a661" />

