### PR TITLE
fix(grid): should not close editor panel when click panel

### DIFF
--- a/packages/grid/src/services/event.service.ts
+++ b/packages/grid/src/services/event.service.ts
@@ -181,7 +181,7 @@ export class AITableGridEventService {
                 aiTable: aiTable
             },
             panelClass: 'grid-cell-editor',
-            outsideClosable: true,
+            outsideClosable: false,
             hasBackdrop: false,
             manualClosure: true,
             animationDisabled: true,


### PR DESCRIPTION
日期面板、选人下拉面板的使用，修复后：
- 点击面板单选多选值正常关闭面板；
- 点击面板外部正常关闭面板；
- 点击切换月份年份，点击切换成员到团队tab，不关闭面板。