### PR TITLE
refactor: use map instead of array.find to improve performance

### DIFF
--- a/packages/grid/src/components/field-menu/field-menu.component.ts
+++ b/packages/grid/src/components/field-menu/field-menu.component.ts
@@ -29,7 +29,7 @@ export class AITableFieldMenu extends ThyDropdownAbstractMenu {
     @Input() position!: { x: number; y: number };
 
     field = computed(() => {
-        return this.aiTable.fields().find((item) => item._id === this.fieldId)!;
+        return this.aiTable.fieldsMap()[this.fieldId];
     });
 
     execute(menu: AITableFieldMenuItem) {

--- a/packages/grid/src/core/utils/field.ts
+++ b/packages/grid/src/core/utils/field.ts
@@ -3,6 +3,7 @@ import { AITableField, AITableFieldOption, AITableFieldType, IsMultiple, MemberS
 import { generateNewName } from './common';
 import { idCreator } from './id-creator';
 import { AITable } from '../types';
+import * as _ from 'lodash';
 
 export const isArrayField = (field: AITableField) => {
     return [
@@ -72,6 +73,7 @@ export function isSameFieldOption(fieldOption: AITableFieldOption, field: Partia
 
 export function createDefaultField(aiTable: AITable, type: AITableFieldType = AITableFieldType.text) {
     const fieldOptions = getFieldOptions(aiTable);
-    const fieldOption = fieldOptions.find((item) => item.type === type)!;
+    const fieldOptionTypesMap = _.keyBy(fieldOptions, 'type');
+    const fieldOption = fieldOptionTypesMap[type]!;
     return { _id: idCreator(), type, name: createDefaultFieldName(aiTable, fieldOption) };
 }

--- a/packages/grid/src/core/utils/queries.ts
+++ b/packages/grid/src/core/utils/queries.ts
@@ -79,7 +79,8 @@ export const AITableQueries = {
         if (!path) {
             throw new Error(`path does not exist as path [${path}]`);
         }
-        return aiTable.gridData().fields.find((item) => item._id === path[0]);
+        const fieldId = path[0];
+        return aiTable.fieldsMap()[fieldId];
     },
 
     getRecord(aiTable: AITable, path: NumberPath): AITableRecord {

--- a/packages/grid/src/pipes/grid.pipe.ts
+++ b/packages/grid/src/pipes/grid.pipe.ts
@@ -10,6 +10,7 @@ import {
 } from '@ai-table/utils';
 import { isSameFieldOption } from '../core';
 import { AITableSelection } from '../types';
+import * as _ from 'lodash';
 
 @Pipe({
     name: 'selectOption',
@@ -17,7 +18,8 @@ import { AITableSelection } from '../types';
 })
 export class SelectOptionPipe implements PipeTransform {
     transform(_id: string, options: AITableSelectOption[]) {
-        return options?.length && options.find((item) => item._id === _id);
+        const optionsMap = _.keyBy(options || [], '_id');
+        return optionsMap[_id];
     }
 }
 
@@ -27,10 +29,11 @@ export class SelectOptionPipe implements PipeTransform {
 })
 export class SelectOptionsPipe implements PipeTransform {
     transform(ids: string[], options: AITableSelectOption[] = []) {
+        const optionsMap = _.keyBy(options || [], '_id');
         return (
             (ids?.length &&
                 ids.map((id: string) => {
-                    return options.find((item) => item._id === id);
+                    return optionsMap[id];
                 })) ||
             []
         );

--- a/packages/grid/src/renderer/creations/create-active-cell-border.ts
+++ b/packages/grid/src/renderer/creations/create-active-cell-border.ts
@@ -38,7 +38,8 @@ export const createActiveCellBorder = (config: AITableCellsConfig) => {
             const { type } = linearRows()[rowIndex];
 
             if (type === AITableRowType.record) {
-                const activeField = visibleColumns.find((field) => field._id === fieldId);
+                const fieldsMap = aiTable.fieldsMap();
+                const activeField = fieldsMap[fieldId];
                 if (activeField == null) {
                     return {
                         activeCellBorder,

--- a/packages/grid/src/renderer/drawers/cell-drawer.ts
+++ b/packages/grid/src/renderer/drawers/cell-drawer.ts
@@ -213,8 +213,10 @@ export class CellDrawer extends Drawer {
         let totalWidth = 0;
         const cellItemInfoMap = new Map();
         let drawableIndex = 0;
+        const optionsMap = helpers.keyBy((field as AITableSelectField).settings.options || [], '_id');
+
         transformValue.forEach((optionId, index) => {
-            const item = (field as AITableSelectField).settings.options?.find((option) => option._id === optionId);
+            const item = optionsMap[optionId];
             const textWidth = getTextWidth(ctx, item?.text as string, fontStyle);
             totalWidth += textWidth + 2 * AI_TABLE_CELL_PADDING;
             if (index < transformValue.length - 1) {
@@ -413,7 +415,8 @@ export class CellDrawer extends Drawer {
             console.warn(`single select field unexpected value: ${transformValue[0]}`);
         }
         const isOperating = isActive;
-        const item = (field as AITableSelectField).settings.options?.find((option) => option._id === transformValue[0]);
+        const optionsMap = helpers.keyBy((field as AITableSelectField).settings.options || [], '_id');
+        const item = optionsMap[transformValue[0]];
         const itemName = item?.text || '';
         const getTextEllipsis = (maxTextWidth: number, fontSize: number = AI_TABLE_COMMON_FONT_SIZE) => {
             maxTextWidth -= isOperating ? AI_TABLE_CELL_DELETE_ITEM_BUTTON_SIZE - AI_TABLE_CELL_DELETE_ITEM_BUTTON_SIZE_OFFSET : 0;

--- a/packages/grid/src/utils/build.ts
+++ b/packages/grid/src/utils/build.ts
@@ -2,7 +2,7 @@ import { AITable, getFieldOptions } from '../core';
 import { AITableGridData, AITableLinearRow } from '../types';
 import { AITableRowType } from '../types/row';
 import { AITableFields, AITableRecords } from '@ai-table/utils';
-
+import * as _ from 'lodash';
 export const buildGridLinearRows = (visibleRecords: AITableRecords, isAddingVisible: boolean = true): AITableLinearRow[] => {
     const linearRows: AITableLinearRow[] = [];
     let displayRowIndex = 0;
@@ -27,8 +27,9 @@ export const buildGridLinearRows = (visibleRecords: AITableRecords, isAddingVisi
 
 export const buildGridData = (aiTable: AITable, recordValue: AITableRecords, fieldsValue: AITableFields): AITableGridData => {
     const fieldOptions = getFieldOptions(aiTable);
+    const fieldOptionTypesMap = _.keyBy(fieldOptions, 'type');
     const fields = fieldsValue.map((value) => {
-        const fieldOption = fieldOptions.find((item) => item.type === value.type)!;
+        const fieldOption = fieldOptionTypesMap[value.type];
         return {
             ...value,
             icon: value.icon || fieldOption.icon

--- a/packages/grid/src/utils/clipboard/paste.ts
+++ b/packages/grid/src/utils/clipboard/paste.ts
@@ -14,7 +14,7 @@ import {
     AddFieldOptions,
     AITableReferences
 } from '@ai-table/utils';
-
+import * as _ from 'lodash';
 const aiTableAttributePattern = new RegExp(`${aiTableFragmentAttribute}="(.+?)"`, 'm');
 
 const decodeClipboardJsonData = (encoded: string) => {
@@ -179,9 +179,10 @@ function appendField(aiTable: AITable, originField: AITableField | null, actions
     let defaultFieldValue: Partial<AITableField>;
     if (originField) {
         const fieldOptions = getFieldOptions(aiTable);
+        const fieldOptionTypesMap = _.keyBy(fieldOptions, 'type');
         defaultFieldValue = {
             ...originField,
-            name: createDefaultFieldName(aiTable, fieldOptions.find((item) => item.type === originField.type)!),
+            name: createDefaultFieldName(aiTable, fieldOptionTypesMap[originField.type]!),
             _id: idCreator()
         };
     } else {

--- a/packages/grid/src/utils/field/model/member.ts
+++ b/packages/grid/src/utils/field/model/member.ts
@@ -14,6 +14,7 @@ import {
 import { FieldOperable } from '../field-operable';
 import { isEmpty } from 'lodash';
 import { AITable } from '../../../core';
+import * as _ from 'lodash';
 
 export class MemberField extends MemberFieldBase implements FieldOperable<string, MemberFieldValue> {
     isMeetFilter(condition: AITableFilterCondition<string>, cellValue: MemberFieldValue) {
@@ -89,8 +90,10 @@ export function toMemberFieldValue(
             .filter((id) => !!id);
         const memberInfos = Object.values(references.members);
         let validMemberIds: MemberFieldValue = [];
+        const memberNamesMap = _.keyBy(memberInfos, 'display_name');
+
         memberNames.forEach((memberName) => {
-            const memberInfo = memberInfos.find((member) => member.display_name === memberName);
+            const memberInfo = memberNamesMap[memberName];
             if (memberInfo) {
                 validMemberIds.push(memberInfo.uid as Id);
             }

--- a/packages/grid/src/utils/field/model/select.ts
+++ b/packages/grid/src/utils/field/model/select.ts
@@ -17,6 +17,7 @@ import {
 } from '@ai-table/utils';
 import { FieldOperable } from '../field-operable';
 import { isEmpty } from 'lodash';
+import * as _ from 'lodash';
 
 export class SelectField extends SelectFieldBase implements FieldOperable<string, SelectFieldValue> {
     override isValid(cellValue: FieldValue): boolean {
@@ -91,11 +92,13 @@ export function processPastedValueForSelect(
         if (cellValue && Array.isArray(cellValue) && cellValue.length) {
             const targetOptionIds = targetFieldOptions.map((option) => option._id);
             const originOptionsMap = helpers.keyBy((field.settings as SelectSettings)?.options || [], '_id');
+            const originOptionTextsMap = _.keyBy(targetFieldOptions, 'text');
+
             cellValue.forEach((id) => {
                 if (targetOptionIds.includes(id)) {
                     existOptionIds.push(id);
-                } else if (targetFieldOptions.some((option) => option.text === originOptionsMap[id]?.text)) {
-                    const option = targetFieldOptions.find((option: AITableSelectOption) => option.text === originOptionsMap[id].text);
+                } else if (originOptionTextsMap[originOptionsMap[id]?.text]) {
+                    const option = originOptionTextsMap[originOptionsMap[id].text];
                     existOptionIds.push(option!._id);
                 } else {
                     const originOption = originOptionsMap[id];
@@ -107,8 +110,9 @@ export function processPastedValueForSelect(
             });
         }
     } else {
+        const targetFieldOptionTextsMap = _.keyBy(targetFieldOptions, 'text');
         cellFullTexts.forEach((text) => {
-            const option = targetFieldOptions.find((option) => option.text === text);
+            const option = targetFieldOptionTextsMap[text];
             if (option) {
                 existOptionIds.push(option._id);
             } else {

--- a/packages/state/src/action/field.ts
+++ b/packages/state/src/action/field.ts
@@ -35,7 +35,8 @@ export function moveField(aiTable: AIViewTable, path: NumberPath, newPath: Numbe
         return;
     }
     const fields = aiTable.gridData().fields;
-    const activeView = aiTable.views().find((item) => item._id === aiTable.activeViewId());
+    const viewsMap = aiTable.viewsMap();
+    const activeView = viewsMap[aiTable.activeViewId()];
     const sourceField = fields[path[0]] as AITableViewField;
     const position = getFieldPositionInView(activeView!._id, fields, path, newPath);
     setField(aiTable, { positions: { ...sourceField.positions, [activeView!._id]: position } }, [sourceField._id]);
@@ -43,7 +44,8 @@ export function moveField(aiTable: AIViewTable, path: NumberPath, newPath: Numbe
 
 export function setFieldWidth(aiTable: AIViewTable, path: IdPath, width: number) {
     const field = AITableQueries.getField(aiTable, path) as AITableViewField;
-    const activeView = aiTable.views().find((item) => item._id === aiTable.activeViewId());
+    const viewsMap = aiTable.viewsMap();
+    const activeView = viewsMap[aiTable.activeViewId()];
     setField(aiTable, { widths: { ...field.widths, [activeView!._id]: width } }, [field._id]);
 }
 

--- a/packages/state/src/action/general.ts
+++ b/packages/state/src/action/general.ts
@@ -13,8 +13,13 @@ import {
     AITableViewRecord,
     AITableViewRecords
 } from '@ai-table/utils';
+import * as _ from 'lodash';
 
 const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITableFields, views: AITableView[], action: AITableAction) => {
+    const viewsMap = _.keyBy(views, '_id');
+    const fieldsMap = _.keyBy(fields, '_id');
+    const recordsMap = _.keyBy(records, '_id');
+
     switch (action.type) {
         case ActionName.UpdateFieldValue: {
             const [recordId, fieldId] = action.path;
@@ -79,7 +84,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         }
 
         case ActionName.SetField: {
-            const field = fields.find((item) => item._id === action.path[0]) as AITableField;
+            const field = fieldsMap[action.path[0]]!;
             if (field) {
                 for (const key in action.newProperties) {
                     const k = key as keyof AITableField;
@@ -101,7 +106,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
             break;
         }
         case ActionName.SetView: {
-            const view = views.find((item) => item._id === action.path[0]) as AITableView;
+            const view = viewsMap[action.path[0]]!;
             if (view) {
                 for (const key in action.newProperties) {
                     const k = key as keyof AITableView;
@@ -136,7 +141,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         }
         case ActionName.SetRecordPositions: {
             const { positions, path } = action;
-            const record = records.find((item) => item._id === path[0]);
+            const record = recordsMap[path[0]]!;
             if (record) {
                 const newPositions = { ...record.positions };
                 for (const key in positions) {

--- a/packages/state/src/action/view.ts
+++ b/packages/state/src/action/view.ts
@@ -3,7 +3,8 @@ import { AIViewTable } from '../types/ai-table';
 import { sortViews } from '../utils';
 
 function setView(aiTable: AIViewTable, value: Partial<AITableView>, path: [string]) {
-    const view = aiTable.views().find((item) => item._id === path[0]);
+    const viewsMap = aiTable.viewsMap();
+    const view = viewsMap[path[0]]!;
     if (view) {
         const properties: Partial<AITableView> = {};
         const newProperties: Partial<AITableView> = {};

--- a/packages/state/src/shared/to-table/map-event.ts
+++ b/packages/state/src/shared/to-table/map-event.ts
@@ -12,7 +12,8 @@ export default function translateMapEvent(aiTable: AIViewTable, sharedType: Shar
         if (isFieldsTranslate) {
             const field = sharedType.get('fields')?.get(targetPath) as SyncMapElement;
             const fieldId = field && field.get('_id');
-            targetElement = fieldId && aiTable.gridData().fields.find((item) => item._id === field.get('_id'));
+            const fieldsMap = aiTable.fieldsMap();
+            targetElement = fieldId && fieldsMap[fieldId];
         }
 
         if (isViewTranslate) {

--- a/packages/state/src/utils/record/filter.ts
+++ b/packages/state/src/utils/record/filter.ts
@@ -16,6 +16,7 @@ import {
     AITableFilterCondition,
     AITableFilterOperation
 } from '@ai-table/utils';
+import * as _ from 'lodash';
 import { isEmpty } from 'lodash';
 
 export function getFilteredRecords(aiTable: AIViewTable, records: AITableViewRecords, fields: AITableViewFields, activeView: AITableView) {
@@ -145,7 +146,8 @@ export function getDefaultRecordDataByFilter(
 }
 
 function getFilterValue(fields: AITableViewFields, record: AITableRecord, condition: AITableFilterCondition) {
-    const field = fields.find((item) => item._id === condition.field_id);
+    const fieldsMap = _.keyBy(fields || [], '_id');
+    const field = fieldsMap[condition.field_id];
     let cellValue = null;
     if (field && isSystemField(field)) {
         if ([AITableFieldType.createdAt, AITableFieldType.updatedAt].includes(field.type)) {

--- a/packages/state/src/utils/record/move-records.ts
+++ b/packages/state/src/utils/record/move-records.ts
@@ -1,14 +1,16 @@
 import { getMaxPosition } from '../view';
 import { sortByViewPosition } from '../common';
 import { Actions } from '../../action';
-import { AITableRecordUpdatedInfo, AITableView, AITableViewRecords, MoveRecordOptions } from '@ai-table/utils';
+import { AITableRecordUpdatedInfo, AITableViewRecords, MoveRecordOptions } from '@ai-table/utils';
 import { AIViewTable } from '../../types';
 
 export function moveRecords(aiTable: AIViewTable, options: MoveRecordOptions, updatedInfo: AITableRecordUpdatedInfo) {
     const records = aiTable.gridData().records as AITableViewRecords;
     const activeViewId = aiTable.activeViewId();
-    const activeView = aiTable.views().find((view) => view._id === activeViewId) as AITableView;
+    const viewsMap = aiTable.viewsMap();
+    const activeView = viewsMap[activeViewId]!;
     const { recordIds, newPath } = options;
+
     let targetPosition = 0;
     let prevPosition = 0;
     if (newPath[0] === 0) {
@@ -21,7 +23,12 @@ export function moveRecords(aiTable: AIViewTable, options: MoveRecordOptions, up
         targetPosition = records[newPath[0]].positions[activeViewId]!;
         prevPosition = records[newPath[0] - 1].positions[activeViewId]!;
     }
-    const sourceRecords = recordIds.map((idPath) => records.find((record) => record._id === idPath[0])!);
+
+    const recoredsMap = aiTable.recordsMap();
+    const sourceRecords = recordIds.map((idPath) => {
+        return recoredsMap[idPath[0]]!;
+    }) as AITableViewRecords;
+
     // 勾选多行顺序可能不一致，需要排序
     const sortedSourceRecords = sortByViewPosition(sourceRecords, activeView);
     let nextPosition = (prevPosition + targetPosition) / 2;

--- a/packages/state/src/utils/view.ts
+++ b/packages/state/src/utils/view.ts
@@ -64,7 +64,8 @@ export function addView(aiTable: AIViewTable, type: 'add' | 'duplicate', viewId?
     let originViewId = views[views.length - 1]._id;
     if (type === 'duplicate') {
         originViewId = viewId ?? aiTable.activeViewId();
-        const copyView = views.find((item) => item._id === originViewId)!;
+        const viewsMap = aiTable.viewsMap();
+        const copyView = viewsMap[originViewId]!;
 
         const copyName = copyView.name;
         const copyViewName = generateCopyName(aiTable, allViewNames, copyName);


### PR DESCRIPTION
10000行&30列数据量时，发现 Array.find 比较耗时：
![image](https://github.com/user-attachments/assets/f0e964de-4619-4eac-ba3b-f0d6e0c70920)

改成 Map 