### PR TITLE
refactor(grid): refactor public function transformCellValue to transformToCellText

### DIFF
--- a/packages/grid/src/renderer/components/cover-cell.component.ts
+++ b/packages/grid/src/renderer/components/cover-cell.component.ts
@@ -1,10 +1,10 @@
-import { ChangeDetectionStrategy, Component, computed, effect, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { KoContainer } from '../../angular-konva';
 import { AITableCellsConfig, AITableCoverCellConfig } from '../../types';
 import { AITableFieldType } from '@ai-table/utils';
 import { CommonModule } from '@angular/common';
 import { AI_TABLE_CELL_PADDING, AI_TABLE_OFFSET, DEFAULT_TEXT_ALIGN_LEFT, DEFAULT_TEXT_ALIGN_RIGHT } from '../../constants';
-import { AITableQueries, FieldModelMap, getCellHorizontalPosition, getCoverCell, transformCellValue } from '../../utils';
+import { AITableQueries, FieldModelMap, getCellHorizontalPosition, getCoverCell } from '../../utils';
 import { isSelectedField } from '../creations/create-cells';
 import _ from 'lodash';
 import { Constructor } from 'ngx-tethys/core';

--- a/packages/grid/src/utils/cell.ts
+++ b/packages/grid/src/utils/cell.ts
@@ -1,7 +1,5 @@
-import { AIRecordFieldIdPath, AITableField, AITableFieldOption, AITableSizeMap, FieldValue } from '@ai-table/utils';
+import { AIRecordFieldIdPath, AITableField, AITableFieldOption, AITableSizeMap, FieldValue, FieldOptions } from '@ai-table/utils';
 import { AITable, getFieldOptionByField } from '../core';
-import { AI_TABLE_GRID_FIELD_SERVICE_MAP } from '../services';
-import { FieldModelMap } from './field';
 
 export function getColumnIndicesSizeMap(aiTable: AITable, fields: AITableField[]) {
     const fieldSizeMap = aiTable.gridData().fieldsSizeMap;
@@ -21,33 +19,19 @@ export function getCellHorizontalPosition(options: { columnWidth: number; column
     return { width: columnWidth, offset: 0 };
 }
 
-// @deprecated 请使用 FieldModelMap 的 transformCellValue 方法
-// const fieldModel = FieldModelMap[field.type];
-// const transformValue = fieldModel.transformCellValue(cellValue, { aiTable, field });
-export function transformCellValue<T = any>(aiTable: AITable, field: AITableField, cellValue: FieldValue): T | null {
-    const fieldModel = FieldModelMap[field.type];
-    if (!fieldModel.isValid(cellValue)) {
-        return null;
-    }
-
-    const fieldService = AI_TABLE_GRID_FIELD_SERVICE_MAP.get(aiTable);
-
-    if (!fieldService) {
+export function transformToCellText<T = any>(cellValue: FieldValue, options: FieldOptions): T | null {
+    const { aiTable, field } = options;
+    const fieldRenderers = aiTable?.context?.aiFieldConfig()?.fieldRenderers;
+    if (!fieldRenderers || !field) {
         return cellValue;
     }
 
-    const fieldRenderers = fieldService.aiFieldConfig?.fieldRenderers;
-    if (!fieldRenderers) {
+    const transform = fieldRenderers[field.type]?.transform;
+    if (!transform) {
         return cellValue;
     }
 
-    const cellTransform = fieldRenderers[field.type]?.transform;
-    if (!cellTransform) {
-        return cellValue;
-    }
-
-    const cellText = cellTransform(field, cellValue);
-
+    const cellText = transform(field, cellValue);
     if (cellText == null) {
         return cellValue;
     }

--- a/packages/grid/src/utils/clipboard/copy.ts
+++ b/packages/grid/src/utils/clipboard/copy.ts
@@ -1,6 +1,5 @@
 import { AITable, getFieldValue, getSystemFieldValue, isSystemField } from '../../core';
 import { FieldModelMap } from '../field';
-import { transformCellValue } from '../cell';
 import { AITableFieldType, AITableRecord, SystemFieldTypes } from '@ai-table/utils';
 import { AITableContent, ClipboardContent } from '../../types';
 

--- a/packages/grid/src/utils/field/field-operable.ts
+++ b/packages/grid/src/utils/field/field-operable.ts
@@ -1,15 +1,8 @@
-import { AITableField, AITableFilterCondition, AITableReferences, FieldBase, FieldValue } from '@ai-table/utils';
+import { AITableField, AITableFilterCondition, AITableReferences, FieldBase, FieldOptions, FieldValue } from '@ai-table/utils';
 import { AITable } from '../../core';
 
 export interface FieldOperable<TFC = string, TCV extends FieldValue = FieldValue> extends FieldBase {
-    isMeetFilter(
-        condition: AITableFilterCondition<TFC>,
-        cellValue: TCV,
-        options?: {
-            aiTable: AITable;
-            field: AITableField;
-        }
-    ): boolean;
+    isMeetFilter(condition: AITableFilterCondition<TFC>, cellValue: TCV, options?: FieldOptions): boolean;
 
     compare(
         cellValue1: TCV,

--- a/packages/grid/src/utils/field/model/attachment.ts
+++ b/packages/grid/src/utils/field/model/attachment.ts
@@ -7,9 +7,9 @@ import {
     AttachmentFieldValue,
     FieldValue,
     AITableFieldType,
-    isEmpty
+    isEmpty,
+    FieldOptions
 } from '@ai-table/utils';
-import { AITable } from '../../../core';
 import { compareString, hasIntersect, isMeetFilter } from '../operate';
 import { FieldOperable } from '../field-operable';
 
@@ -34,13 +34,10 @@ export class AttachmentField extends AttachmentFieldBase implements FieldOperabl
         cellValue2: AttachmentFieldValue,
         references: AITableReferences,
         sortKey: string,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
+        options: FieldOptions
     ): number {
-        const value1 = cellValueToSortValue(cellValue1, options.field, references, sortKey);
-        const value2 = cellValueToSortValue(cellValue2, options.field, references, sortKey);
+        const value1 = cellValueToSortValue(cellValue1, options.field!, references, sortKey);
+        const value2 = cellValueToSortValue(cellValue2, options.field!, references, sortKey);
         return compareString(value1, value2);
     }
 

--- a/packages/grid/src/utils/field/model/date.ts
+++ b/packages/grid/src/utils/field/model/date.ts
@@ -15,11 +15,11 @@ import {
 } from '@ai-table/utils';
 import { FieldOperable } from '../field-operable';
 import { compareNumber, isMeetFilter } from '../operate';
-import { transformCellValue } from '../../cell';
+import { transformToCellText } from '../../cell';
 
 export class DateField extends DateFieldBase implements FieldOperable<string, DateFieldValue> {
     override transformCellValue(cellValue: FieldValue, options: FieldOptions) {
-        return transformCellValue(options.aiTable, options.field!, cellValue);
+        return transformToCellText(cellValue, options);
     }
 
     isMeetFilter(condition: AITableFilterCondition<string>, cellValue: DateFieldValue) {

--- a/packages/grid/src/utils/field/model/member.ts
+++ b/packages/grid/src/utils/field/model/member.ts
@@ -10,10 +10,10 @@ import {
     MemberSettings,
     AITableFilterOperation,
     Id,
-    isEmpty
+    isEmpty,
+    FieldOptions
 } from '@ai-table/utils';
 import { FieldOperable } from '../field-operable';
-import { AITable } from '../../../core';
 
 export class MemberField extends MemberFieldBase implements FieldOperable<string, MemberFieldValue> {
     isMeetFilter(condition: AITableFilterCondition<string>, cellValue: MemberFieldValue) {
@@ -36,13 +36,10 @@ export class MemberField extends MemberFieldBase implements FieldOperable<string
         cellValue2: MemberFieldValue,
         references: AITableReferences,
         sortKey: string,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
+        options: FieldOptions
     ): number {
-        const value1 = cellValueToSortValue(cellValue1, options.field, references, sortKey);
-        const value2 = cellValueToSortValue(cellValue2, options.field, references, sortKey);
+        const value1 = cellValueToSortValue(cellValue1, options.field!, references, sortKey);
+        const value2 = cellValueToSortValue(cellValue2, options.field!, references, sortKey);
         return compareString(value1, value2);
     }
 

--- a/packages/grid/src/utils/field/model/rich-text.ts
+++ b/packages/grid/src/utils/field/model/rich-text.ts
@@ -10,25 +10,18 @@ import {
     RichTextFieldBase,
     isEmpty
 } from '@ai-table/utils';
-import { transformCellValue } from '../../cell';
+import { transformToCellText } from '../../cell';
 import { compareString, isMeetFilter, stringInclude } from '../operate';
 import { FieldOperable } from '../field-operable';
 import { AITable } from '../../../core';
 
 export class RichTextField extends RichTextFieldBase implements FieldOperable<string, RichTextFieldValue> {
     override transformCellValue(cellValue: FieldValue, options: FieldOptions) {
-        return transformCellValue(options.aiTable, options.field!, cellValue);
+        return transformToCellText(cellValue, options);
     }
 
-    isMeetFilter(
-        condition: AITableFilterCondition<string>,
-        cellValue: RichTextFieldValue,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
-    ) {
-        const textValue = transformCellValue(options.aiTable, options.field, cellValue || []);
+    isMeetFilter(condition: AITableFilterCondition<string>, cellValue: RichTextFieldValue, options: FieldOptions) {
+        const textValue = this.transformCellValue(cellValue || [], options);
         switch (condition.operation) {
             case AITableFilterOperation.empty:
                 return isEmpty(textValue);
@@ -46,10 +39,7 @@ export class RichTextField extends RichTextFieldBase implements FieldOperable<st
         cellValue2: RichTextFieldValue,
         references: AITableReferences,
         sortKey: string,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
+        options: FieldOptions
     ): number {
         const value1 = this.transformCellValue(cellValue1 || [], options);
         const value2 = this.transformCellValue(cellValue2 || [], options);

--- a/packages/grid/src/utils/field/model/select.ts
+++ b/packages/grid/src/utils/field/model/select.ts
@@ -17,7 +17,8 @@ import {
     isEmpty,
     idCreator,
     SystemFieldTypes,
-    generateOptionsByTexts
+    generateOptionsByTexts,
+    FieldOptions
 } from '@ai-table/utils';
 import { FieldOperable } from '../field-operable';
 import { compareOption } from '../operate';
@@ -28,14 +29,7 @@ export class SelectField extends SelectFieldBase implements FieldOperable<string
         return Array.isArray(cellValue) || cellValue === null;
     }
 
-    isMeetFilter(
-        condition: AITableFilterCondition<string>,
-        cellValue: SelectFieldValue,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
-    ) {
+    isMeetFilter(condition: AITableFilterCondition<string>, cellValue: SelectFieldValue, options: FieldOptions) {
         const selectOptions = (options?.field?.settings as SelectSettings)?.options || [];
         const validCellValue = getValidCellValue(cellValue, selectOptions);
 
@@ -58,12 +52,9 @@ export class SelectField extends SelectFieldBase implements FieldOperable<string
         cellValue2: SelectFieldValue,
         references: AITableReferences,
         sortKey: string,
-        options: {
-            aiTable: AITable;
-            field: AITableField;
-        }
+        options: FieldOptions
     ): number {
-        const selectOptions = (options.field.settings as SelectSettings)?.options || [];
+        const selectOptions = (options.field?.settings as SelectSettings)?.options || [];
         const validCellValue1 = getValidCellValue(cellValue1, selectOptions);
         const validCellValue2 = getValidCellValue(cellValue2, selectOptions);
 

--- a/packages/grid/src/utils/field/operate.ts
+++ b/packages/grid/src/utils/field/operate.ts
@@ -1,13 +1,4 @@
-import {
-    AITableFilterCondition,
-    AITableFilterOperation,
-    AITableField,
-    FieldValue,
-    isEmpty,
-    AITableSelectOption,
-    Id
-} from '@ai-table/utils';
-import { AITable } from '../../core';
+import { AITableFilterCondition, AITableFilterOperation, FieldValue, isEmpty, AITableSelectOption, Id } from '@ai-table/utils';
 
 export const zhIntlCollator = typeof Intl !== 'undefined' ? new Intl.Collator('zh-CN') : undefined;
 
@@ -95,14 +86,7 @@ export function hasIntersect<T extends number | string>(array1: T[], array2: T[]
     return false;
 }
 
-export function isMeetFilter(
-    condition: AITableFilterCondition,
-    cellValue: FieldValue,
-    options?: {
-        aiTable: AITable;
-        field: AITableField;
-    }
-) {
+export function isMeetFilter(condition: AITableFilterCondition, cellValue: FieldValue) {
     switch (condition.operation) {
         case AITableFilterOperation.empty:
         case AITableFilterOperation.exists: {

--- a/packages/grid/src/utils/match-keywords.ts
+++ b/packages/grid/src/utils/match-keywords.ts
@@ -1,6 +1,5 @@
 import { AITableField, AITableReferences } from '@ai-table/utils';
 import { AITable, AITableQueries } from '../core';
-import { transformCellValue } from './cell';
 import { FieldModelMap } from './field';
 
 export const isCellMatchKeywords = (


### PR DESCRIPTION
之前统一改用 fieldModel.transformCellValue 之后， 原来的 transformCellValue 标记废弃了。
现在：将 transformCellValue 改为 transformToCellText，内部取 transform 函数改为不再依赖 fieldService 服务。