### PR TITLE
feat(grid): support drag to fill fields

### DIFF
--- a/packages/grid/src/constants/table.ts
+++ b/packages/grid/src/constants/table.ts
@@ -32,6 +32,7 @@ export const AI_TABLE_FIELD_HEAD_ICON_GAP_SIZE = 8; // 字段表列头图标的�
 export const AI_TABLE_FIELD_HEAD_MORE = 'AI_TABLE_FIELD_HEAD_MORE'; // 更多图标名称
 export const AI_TABLE_FIELD_HEAD_OPACITY_LINE = 'AI_TABLE_FIELD_HEAD_OPACITY_LINE'; // 字段列头透明线
 export const AI_TABLE_ROW_DRAG = 'AI_TABLE_ROW_DRAG'; // 行拖拽
+export const AI_TABLE_FILL_HANDLE = 'AI_TABLE_FILL_HANDLE'; // 填充手柄
 
 export const AI_TABLE_PREVENT_CLEAR_SELECTION_CLASS = '.ai-table-prevent-clear-selection';
 

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -73,7 +73,7 @@ import {
     FieldModelMap,
     isVirtualKey,
     setMouseStyle,
-    dragFillSelectArea,
+    dragFillHighlightArea,
     performFill,
     AITableDragFillState
 } from './utils';
@@ -444,19 +444,15 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
 
                     if (this.dragFillState.isDragging) {
                         setMouseStyle('crosshair', this.containerElement());
-                        const { dragFillStartCell, dragFillEndCell, direction } = dragFillSelectArea(
+                        const { highlightStartCell, highlightEndCell } = dragFillHighlightArea(
                             this.aiTable,
                             this.dragFillState.sourceCells,
                             recordId
                         );
-                        if (direction !== this.dragFillState.direction) {
-                            this.updateDragFillState({
-                                direction
-                            });
-                        }
+
                         activeCell = this.aiTable.selection().activeCell;
-                        startCell = dragFillStartCell;
-                        endCell = dragFillEndCell;
+                        startCell = highlightStartCell;
+                        endCell = highlightEndCell;
                     } else {
                         startCell = this.dragSelectState.startCell!;
                         endCell = [recordId, fieldId];
@@ -540,10 +536,35 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
     stageMouseup(e: KoEventObject<MouseEvent>) {
         this.updateDragSelectState(false, null);
 
-        if (this.dragFillState.isDragging && this.dragFillState.direction) {
-            performFill(this.aiTable, this.dragFillState, this.actions);
-            this.updateDragFillState({ isDragging: false, sourceCells: new Set<string>() });
+        if (this.dragFillState.isDragging) {
+            this.performFill(e);
         }
+    }
+
+    private performFill(e: KoEventObject<MouseEvent>) {
+        const targetName = e.event.target.name();
+        const gridStage = e.event.currentTarget.getStage();
+        const pos = gridStage?.getPointerPosition();
+        if (pos == null) {
+            this.updateDragFillState({ isDragging: false, sourceCells: new Set<string>() });
+            return;
+        }
+        const { context } = this.aiTable;
+        const { x, y } = pos;
+        const curMousePosition = getMousePosition(
+            this.aiTable,
+            x,
+            y,
+            this.coordinate(),
+            AITable.getVisibleFields(this.aiTable),
+            context!,
+            targetName
+        );
+        const { recordId } = getDetailByTargetName(curMousePosition.realTargetName);
+        if (recordId) {
+            performFill(this.aiTable, this.dragFillState.sourceCells, recordId, this.actions);
+        }
+        this.updateDragFillState({ isDragging: false, sourceCells: new Set<string>() });
     }
 
     stageMouseleave(e: KoEventObject<MouseEvent>) {
@@ -786,11 +807,8 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         };
     }
 
-    private updateDragFillState(updates: Partial<AITableDragFillState>) {
-        this.dragFillState = {
-            ...this.dragFillState,
-            ...updates
-        };
+    private updateDragFillState(dragFillState: AITableDragFillState) {
+        this.dragFillState = dragFillState;
     }
 
     private resetScrolling = () => {

--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -31,6 +31,7 @@ import {
     AI_TABLE_FIELD_HEAD_MORE,
     AI_TABLE_FIELD_HEAD_OPACITY_LINE,
     AI_TABLE_FIELD_HEAD_SELECT_CHECKBOX,
+    AI_TABLE_FILL_HANDLE,
     AI_TABLE_PREVENT_CLEAR_SELECTION_CLASS,
     AI_TABLE_ROW_ADD_BUTTON,
     AI_TABLE_ROW_DRAG,
@@ -70,7 +71,11 @@ import {
     isWindows,
     clearCells,
     FieldModelMap,
-    isVirtualKey
+    isVirtualKey,
+    setMouseStyle,
+    dragFillSelectArea,
+    performFill,
+    AITableDragFillState
 } from './utils';
 import { getMousePosition } from './utils/position';
 import { AITableDragComponent } from './components/drag/drag.component';
@@ -108,11 +113,20 @@ import _ from 'lodash';
 export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
     private viewContainerRef = inject(ViewContainerRef);
 
-    private isDragSelecting = false;
-
     private isDragSelectionAutoScrolling = false;
 
-    private dragSelectionStart: AIRecordFieldIdPath | null = null;
+    private dragSelectState: {
+        isDragging: boolean;
+        startCell: AIRecordFieldIdPath | null;
+    } = {
+        isDragging: false,
+        startCell: null
+    };
+
+    private dragFillState: AITableDragFillState = {
+        isDragging: false,
+        sourceCells: new Set<string>()
+    };
 
     private notifyService = inject(ThyNotifyService);
 
@@ -420,13 +434,36 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
                 this.setDefaultPointPosition();
             }
             this.timer = null;
-            if (this.isDragSelecting) {
+
+            if (this.dragSelectState.isDragging || this.dragFillState.isDragging) {
                 const { fieldId, recordId } = getDetailByTargetName(curMousePosition.realTargetName);
                 if (fieldId && recordId) {
-                    const startCell = this.dragSelectionStart;
-                    const endCell: AIRecordFieldIdPath = [recordId, fieldId];
+                    let startCell: AIRecordFieldIdPath;
+                    let endCell: AIRecordFieldIdPath;
+                    let activeCell: AIRecordFieldIdPath | null = null;
+
+                    if (this.dragFillState.isDragging) {
+                        setMouseStyle('crosshair', this.containerElement());
+                        const { dragFillStartCell, dragFillEndCell, direction } = dragFillSelectArea(
+                            this.aiTable,
+                            this.dragFillState.sourceCells,
+                            recordId
+                        );
+                        if (direction !== this.dragFillState.direction) {
+                            this.updateDragFillState({
+                                direction
+                            });
+                        }
+                        activeCell = this.aiTable.selection().activeCell;
+                        startCell = dragFillStartCell;
+                        endCell = dragFillEndCell;
+                    } else {
+                        startCell = this.dragSelectState.startCell!;
+                        endCell = [recordId, fieldId];
+                    }
+
                     if (startCell && !!startCell.length) {
-                        this.aiTableGridSelectionService.selectCells(startCell, endCell);
+                        this.aiTableGridSelectionService.selectCells(startCell, endCell, activeCell);
                         this.scrollViewToCell(pos, startCell, endCell, this.coordinate(), this.horizontalBarRef(), this.verticalBarRef());
                     }
                 }
@@ -462,12 +499,19 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
                 return;
             case AI_TABLE_CELL:
                 if (!recordId || !fieldId) return;
-                const dragSelectionStart: AIRecordFieldIdPath = [recordId, fieldId];
-                this.updateDragSelectionState(true, dragSelectionStart);
+                const startCell: AIRecordFieldIdPath = [recordId, fieldId];
+                this.updateDragSelectState(true, startCell);
                 const [expandRecordId, expandFieldId] = this.aiTable.selection().expandCell || [null, null];
                 if (expandRecordId !== recordId || expandFieldId !== fieldId) {
-                    this.aiTableGridSelectionService.selectCells(dragSelectionStart);
+                    this.aiTableGridSelectionService.selectCells(startCell);
                 }
+                return;
+            case AI_TABLE_FILL_HANDLE:
+                if (!recordId || !fieldId) return;
+                this.updateDragFillState({
+                    isDragging: true,
+                    sourceCells: this.aiTable.selection().selectedCells
+                });
                 return;
             case AI_TABLE_ROW_DRAG:
                 if (!recordId) return;
@@ -494,12 +538,17 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
     }
 
     stageMouseup(e: KoEventObject<MouseEvent>) {
-        this.updateDragSelectionState(false, null);
+        this.updateDragSelectState(false, null);
+
+        if (this.dragFillState.isDragging && this.dragFillState.direction) {
+            performFill(this.aiTable, this.dragFillState, this.actions);
+            this.updateDragFillState({ isDragging: false, sourceCells: new Set<string>() });
+        }
     }
 
     stageMouseleave(e: KoEventObject<MouseEvent>) {
         if (!this.isDragSelectionAutoScrolling) {
-            this.updateDragSelectionState(false, null);
+            this.updateDragSelectState(false, null);
         }
         if (this.timer) {
             cancelAnimationFrame(this.timer);
@@ -725,14 +774,23 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
                 takeUntilDestroyed(this.destroyRef)
             )
             .subscribe(() => {
-                this.updateDragSelectionState(false, null);
+                this.updateDragSelectState(false, null);
                 this.aiTableGridSelectionService.clearSelection();
             });
     }
 
-    private updateDragSelectionState(isDragSelecting: boolean, dragSelectionStart: AIRecordFieldIdPath | null) {
-        this.isDragSelecting = isDragSelecting;
-        this.dragSelectionStart = dragSelectionStart;
+    private updateDragSelectState(isDragging: boolean, startCell: AIRecordFieldIdPath | null) {
+        this.dragSelectState = {
+            isDragging: isDragging,
+            startCell: startCell
+        };
+    }
+
+    private updateDragFillState(updates: Partial<AITableDragFillState>) {
+        this.dragFillState = {
+            ...this.dragFillState,
+            ...updates
+        };
     }
 
     private resetScrolling = () => {
@@ -971,7 +1029,7 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         this.scrollControllerService.scroll({
             container: containerRect,
             target: position,
-            direction: isSelectionOnlyOnFrozenColumn ? 'vertical' : 'both',
+            direction: isSelectionOnlyOnFrozenColumn || this.dragFillState.isDragging ? 'vertical' : 'both',
             scrollableElement: {
                 horizontalElement: horizontalBarRef?.nativeElement,
                 verticalElement: verticalBarRef?.nativeElement
@@ -1006,7 +1064,7 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
             },
             onAutoScrollEnd: () => {
                 this.isDragSelectionAutoScrolling = false;
-                this.updateDragSelectionState(false, null);
+                this.updateDragSelectState(false, null);
             }
         });
     }

--- a/packages/grid/src/renderer/components/fill-handle.component.ts
+++ b/packages/grid/src/renderer/components/fill-handle.component.ts
@@ -1,0 +1,61 @@
+import { KoShape } from '../../angular-konva';
+import { Component, computed, input } from '@angular/core';
+import { AITableFillHandleConfig } from '../../types';
+import { AI_TABLE_CELL_BORDER, AI_TABLE_FILL_HANDLE, AI_TABLE_OFFSET, AI_TABLE_ROW_HEIGHT, Colors } from '../../constants';
+import { generateTargetName } from '../../utils';
+
+@Component({
+    selector: 'ai-table-fill-handle',
+    template: `
+        @if (hasSelectedCells() && !readonly()) {
+            <ko-rect [config]="handleConfig()"></ko-rect>
+        }
+    `,
+    imports: [KoShape]
+})
+export class AITableFillHandle {
+    readonly config = input.required<AITableFillHandleConfig>();
+
+    readonly hasSelectedCells = computed(() => {
+        return this.config().aiTable.selection().selectedCells.size > 0;
+    });
+
+    readonly readonly = computed(() => {
+        return this.config().readonly;
+    });
+
+    readonly handleConfig = computed(() => {
+        const { aiTable, coordinate } = this.config();
+        const selectedCells = Array.from(aiTable.selection().selectedCells);
+        const lastCell = selectedCells[selectedCells.length - 1];
+        const [recordId, fieldId] = lastCell.split(':');
+        const { scrollLeft, scrollTop } = aiTable.context!.scrollState();
+
+        const columnIndex = aiTable.context!.visibleColumnsIndexMap().get(fieldId)!;
+        const columnOffset = coordinate.getColumnOffset(columnIndex);
+        const columnWidth = coordinate.getColumnWidth(columnIndex);
+        const x = columnOffset + columnWidth - scrollLeft;
+
+        const rowIndex = aiTable.context!.visibleRowsIndexMap().get(recordId)!;
+        const rowOffset = coordinate.getRowOffset(rowIndex);
+        const y = rowOffset + AI_TABLE_ROW_HEIGHT - scrollTop;
+
+        const width = 6;
+        const height = 6;
+
+        return {
+            x: x - width / 2 + AI_TABLE_OFFSET,
+            y: y - height + AI_TABLE_CELL_BORDER + AI_TABLE_OFFSET,
+            width,
+            height,
+            fill: Colors.primary,
+            stroke: Colors.white,
+            strokeWidth: 2,
+            name: generateTargetName({
+                targetName: AI_TABLE_FILL_HANDLE,
+                fieldId,
+                recordId
+            })
+        };
+    });
+}

--- a/packages/grid/src/renderer/renderer.component.html
+++ b/packages/grid/src/renderer/renderer.component.html
@@ -64,6 +64,10 @@
                     }
                 </ko-group>
             </ko-group>
+
+            <ko-group>
+                <ai-table-fill-handle [config]="fillHandleConfig()"></ai-table-fill-handle>
+            </ko-group>
         </ko-group>
     </ko-layer>
 </ko-stage>

--- a/packages/grid/src/renderer/renderer.component.ts
+++ b/packages/grid/src/renderer/renderer.component.ts
@@ -3,7 +3,7 @@ import Konva from 'konva';
 import { StageConfig } from 'konva/lib/Stage';
 import { KoContainer, KoEventObject, KoShape, KoStage } from '../angular-konva';
 import { AITable } from '../core';
-import { AITableCellsConfig, AITableRendererConfig } from '../types';
+import { AITableCellsConfig, AITableFillHandleConfig, AITableRendererConfig } from '../types';
 import { getVisibleRangeInfo } from '../utils';
 import {
     AITableAddField,
@@ -17,6 +17,7 @@ import {
     AITablePlaceholderCells
 } from './components';
 import { createActiveCellBorder } from './creations/create-active-cell-border';
+import { AITableFillHandle } from './components/fill-handle.component';
 import { AITableCoverCells } from './components/cover-cell.component';
 import { AITableFieldStats } from './components/field-stat/stats.component';
 
@@ -39,6 +40,7 @@ Konva.pixelRatio = 2;
         AITableAddField,
         AITableHoverRowHeads,
         AITableOtherRows,
+        AITableFillHandle,
         AITableFieldStats
     ],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -218,6 +220,14 @@ export class AITableRenderer {
             columnStopIndex,
             actions,
             maxRecords
+        };
+    });
+
+    readonly fillHandleConfig = computed<AITableFillHandleConfig>(() => {
+        return {
+            aiTable: this.config().aiTable,
+            coordinate: this.coordinate(),
+            readonly: this.readonly()
         };
     });
 

--- a/packages/grid/src/services/selection.service.ts
+++ b/packages/grid/src/services/selection.service.ts
@@ -117,7 +117,7 @@ export class AITableGridSelectionService {
         }
     }
 
-    selectCells(startCell: AIRecordFieldIdPath, endCell?: AIRecordFieldIdPath) {
+    selectCells(startCell: AIRecordFieldIdPath, endCell?: AIRecordFieldIdPath, activeCell?: AIRecordFieldIdPath | null) {
         const [startRecordId, startFieldId] = startCell;
         const records = this.aiTable.context!.linearRows();
         const fields = AITable.getVisibleFields(this.aiTable);
@@ -146,7 +146,7 @@ export class AITableGridSelectionService {
         }
 
         this.clearSelection();
-        this.setActiveCell(startCell);
+        this.setActiveCell(activeCell || startCell);
         this.aiTable.selection().selectedCells = selectedCells;
     }
 }

--- a/packages/grid/src/types/component-config.ts
+++ b/packages/grid/src/types/component-config.ts
@@ -97,6 +97,12 @@ export interface AITableCoverCellConfig {
     };
 }
 
+export interface AITableFillHandleConfig {
+    aiTable: AITable;
+    coordinate: Coordinate;
+    readonly: boolean;
+}
+
 export interface AITableTargetNameOptions {
     targetName: string;
     fieldId?: string;

--- a/packages/grid/src/utils/drag-fill/drag-fill.ts
+++ b/packages/grid/src/utils/drag-fill/drag-fill.ts
@@ -5,53 +5,54 @@ import { AITableActions } from '../../utils';
 export interface AITableDragFillState {
     isDragging: boolean;
     sourceCells: Set<string>;
-    direction?: 'downward' | 'upward';
 }
 
-export function dragFillSelectArea(aiTable: AITable, sourceCells: Set<string>, currentRecordId: string) {
-    let dragFillStartCell: AIRecordFieldIdPath;
-    let dragFillEndCell: AIRecordFieldIdPath;
+export function getFillDirection(aiTable: AITable, sourceCells: Set<string>, mouseUpRecordId: string) {
+    const { startCell: sourceStartCell, endCell: sourceEndCell } = getStartAndEndCell(sourceCells);
+    const currentRowIndex = aiTable.context!.visibleRowsIndexMap().get(mouseUpRecordId)!;
+    const sourceStartRowIndex = aiTable.context!.visibleRowsIndexMap().get(sourceStartCell[0])!;
+    const sourceEndRowIndex = aiTable.context!.visibleRowsIndexMap().get(sourceEndCell[0])!;
 
-    const { firstCell, lastCell } = getFillAreaBounds(sourceCells);
-
-    const currentRowIndex = aiTable.context!.visibleRowsIndexMap().get(currentRecordId)!;
-    const firstRowIndex = aiTable.context!.visibleRowsIndexMap().get(firstCell[0])!;
-    const lastRowIndex = aiTable.context!.visibleRowsIndexMap().get(lastCell[0])!;
-
-    let direction: 'downward' | 'upward' | undefined = undefined;
-    if (currentRowIndex < firstRowIndex) {
-        direction = 'upward';
-    } else if (currentRowIndex > lastRowIndex) {
-        direction = 'downward';
+    if (currentRowIndex < sourceStartRowIndex) {
+        return 'upward';
+    } else if (currentRowIndex > sourceEndRowIndex) {
+        return 'downward';
+    } else {
+        return undefined;
     }
+}
 
-    const firstCellRecordId = firstCell[0];
-    const firstCellFieldId = firstCell[1];
-    const lastCellRecordId = lastCell[0];
-    const lastCellFieldId = lastCell[1];
+export function dragFillHighlightArea(aiTable: AITable, sourceCells: Set<string>, currentRecordId: string) {
+    const { startCell: sourceStartCell, endCell: sourceEndCell } = getStartAndEndCell(sourceCells);
+    const direction = getFillDirection(aiTable, sourceCells, currentRecordId);
+    const sourceStartCellFieldId = sourceStartCell[1];
+    const sourceEndCellFieldId = sourceEndCell[1];
+
+    let highlightStartCell: AIRecordFieldIdPath;
+    let highlightEndCell: AIRecordFieldIdPath;
 
     if (direction === 'downward') {
-        dragFillStartCell = [firstCellRecordId, firstCellFieldId];
-        dragFillEndCell = [currentRecordId, lastCellFieldId];
+        highlightStartCell = sourceStartCell;
+        highlightEndCell = [currentRecordId, sourceEndCellFieldId];
     } else if (direction === 'upward') {
-        dragFillStartCell = [currentRecordId, firstCellFieldId];
-        dragFillEndCell = [lastCellRecordId, lastCellFieldId];
+        highlightStartCell = [currentRecordId, sourceStartCellFieldId];
+        highlightEndCell = sourceEndCell;
     } else {
-        dragFillStartCell = firstCell;
-        dragFillEndCell = lastCell;
+        highlightStartCell = sourceStartCell;
+        highlightEndCell = sourceEndCell;
     }
 
-    return { dragFillStartCell, dragFillEndCell, direction };
+    return { highlightStartCell, highlightEndCell };
 }
 
-export function performFill(aiTable: AITable, dragFillState: AITableDragFillState, actions: AITableActions) {
+export function performFill(aiTable: AITable, sourceCells: Set<string>, mouseUpRecordId: string, actions: AITableActions) {
     const selectedCells: string[] = Array.from(aiTable.selection().selectedCells);
-    const { sourceCells, direction } = dragFillState;
+
     if (sourceCells.size === 0 || selectedCells.length === 0) {
         return;
     }
 
-    const { firstCell: sourceStartCell, lastCell: sourceEndCell } = getFillAreaBounds(sourceCells);
+    const { startCell: sourceStartCell, endCell: sourceEndCell } = getStartAndEndCell(sourceCells);
     const visibleRowsIndexMap = aiTable.context!.visibleRowsIndexMap();
     const sourceStartRowIndex = visibleRowsIndexMap.get(sourceStartCell[0])!;
     const sourceEndRowIndex = visibleRowsIndexMap.get(sourceEndCell[0])!;
@@ -61,6 +62,7 @@ export function performFill(aiTable: AITable, dragFillState: AITableDragFillStat
 
     let targetStartRowIndex: number;
     let targetEndRowIndex: number;
+    const direction = getFillDirection(aiTable, sourceCells, mouseUpRecordId);
 
     if (direction === 'downward') {
         targetStartRowIndex = sourceEndRowIndex + 1;
@@ -112,15 +114,14 @@ export function performFill(aiTable: AITable, dragFillState: AITableDragFillStat
     }
 }
 
-export function getFillAreaBounds(selectedCells: Set<string>): { firstCell: AIRecordFieldIdPath; lastCell: AIRecordFieldIdPath } {
-    let firstCell: AIRecordFieldIdPath;
-    let lastCell: AIRecordFieldIdPath;
-
+export function getStartAndEndCell(selectedCells: Set<string>): {
+    startCell: AIRecordFieldIdPath;
+    endCell: AIRecordFieldIdPath;
+} {
     const selectedCellsArray = Array.from(selectedCells);
-    const startCell = selectedCellsArray[0].split(':');
-    const endCell = selectedCellsArray[selectedCellsArray.length - 1].split(':');
-    firstCell = [startCell[0], startCell[1]];
-    lastCell = [endCell[0], endCell[1]];
-
-    return { firstCell, lastCell };
+    const firstCell = selectedCellsArray[0].split(':');
+    const lastCell = selectedCellsArray[selectedCellsArray.length - 1].split(':');
+    const startCell = [firstCell[0], firstCell[1]] as AIRecordFieldIdPath;
+    const endCell = [lastCell[0], lastCell[1]] as AIRecordFieldIdPath;
+    return { startCell, endCell };
 }

--- a/packages/grid/src/utils/drag-fill/drag-fill.ts
+++ b/packages/grid/src/utils/drag-fill/drag-fill.ts
@@ -1,0 +1,126 @@
+import { AIRecordFieldIdPath, UpdateFieldValueOptions } from '@ai-table/utils';
+import { AITable } from '../../core';
+import { AITableActions } from '../../utils';
+
+export interface AITableDragFillState {
+    isDragging: boolean;
+    sourceCells: Set<string>;
+    direction?: 'downward' | 'upward';
+}
+
+export function dragFillSelectArea(aiTable: AITable, sourceCells: Set<string>, currentRecordId: string) {
+    let dragFillStartCell: AIRecordFieldIdPath;
+    let dragFillEndCell: AIRecordFieldIdPath;
+
+    const { firstCell, lastCell } = getFillAreaBounds(sourceCells);
+
+    const currentRowIndex = aiTable.context!.visibleRowsIndexMap().get(currentRecordId)!;
+    const firstRowIndex = aiTable.context!.visibleRowsIndexMap().get(firstCell[0])!;
+    const lastRowIndex = aiTable.context!.visibleRowsIndexMap().get(lastCell[0])!;
+
+    let direction: 'downward' | 'upward' | undefined = undefined;
+    if (currentRowIndex < firstRowIndex) {
+        direction = 'upward';
+    } else if (currentRowIndex > lastRowIndex) {
+        direction = 'downward';
+    }
+
+    const firstCellRecordId = firstCell[0];
+    const firstCellFieldId = firstCell[1];
+    const lastCellRecordId = lastCell[0];
+    const lastCellFieldId = lastCell[1];
+
+    if (direction === 'downward') {
+        dragFillStartCell = [firstCellRecordId, firstCellFieldId];
+        dragFillEndCell = [currentRecordId, lastCellFieldId];
+    } else if (direction === 'upward') {
+        dragFillStartCell = [currentRecordId, firstCellFieldId];
+        dragFillEndCell = [lastCellRecordId, lastCellFieldId];
+    } else {
+        dragFillStartCell = firstCell;
+        dragFillEndCell = lastCell;
+    }
+
+    return { dragFillStartCell, dragFillEndCell, direction };
+}
+
+export function performFill(aiTable: AITable, dragFillState: AITableDragFillState, actions: AITableActions) {
+    const selectedCells: string[] = Array.from(aiTable.selection().selectedCells);
+    const { sourceCells, direction } = dragFillState;
+    if (sourceCells.size === 0 || selectedCells.length === 0) {
+        return;
+    }
+
+    const { firstCell: sourceStartCell, lastCell: sourceEndCell } = getFillAreaBounds(sourceCells);
+    const visibleRowsIndexMap = aiTable.context!.visibleRowsIndexMap();
+    const sourceStartRowIndex = visibleRowsIndexMap.get(sourceStartCell[0])!;
+    const sourceEndRowIndex = visibleRowsIndexMap.get(sourceEndCell[0])!;
+
+    const selectedEndCell = selectedCells[selectedCells.length - 1].split(':');
+    const selectedEndRowIndex = visibleRowsIndexMap.get(selectedEndCell[0])!;
+
+    let targetStartRowIndex: number;
+    let targetEndRowIndex: number;
+
+    if (direction === 'downward') {
+        targetStartRowIndex = sourceEndRowIndex + 1;
+        targetEndRowIndex = selectedEndRowIndex;
+    } else {
+        const selectedFirstCell = selectedCells[0].split(':');
+        const selectedFirstRowIndex = visibleRowsIndexMap.get(selectedFirstCell[0])!;
+        targetStartRowIndex = selectedFirstRowIndex;
+        targetEndRowIndex = sourceStartRowIndex - 1;
+    }
+
+    const sourceRowCount = sourceEndRowIndex - sourceStartRowIndex + 1;
+    const sourceRows: string[] = [];
+    const linearRows = aiTable.context!.linearRows();
+    for (let i = sourceStartRowIndex; i <= sourceEndRowIndex; i++) {
+        sourceRows.push(linearRows[i]._id);
+    }
+
+    const updateData: UpdateFieldValueOptions[] = [];
+
+    const fields = AITable.getVisibleFields(aiTable);
+    const visibleColumnsIndexMap = aiTable.context!.visibleColumnsIndexMap();
+    const recordsMap = aiTable.recordsMap();
+
+    const startFieldIndex = visibleColumnsIndexMap.get(sourceStartCell[1])!;
+    const endFieldIndex = visibleColumnsIndexMap.get(sourceEndCell[1])!;
+
+    for (let index = startFieldIndex; index <= endFieldIndex; index++) {
+        const fieldId = fields[index]._id;
+
+        for (let rowIndex = targetStartRowIndex; rowIndex <= targetEndRowIndex; rowIndex++) {
+            const targetRecordId = linearRows[rowIndex]._id;
+
+            const relativeRowIndex = direction === 'downward' ? rowIndex - targetStartRowIndex : targetEndRowIndex - rowIndex;
+            const mod = relativeRowIndex % sourceRowCount;
+            const sourceRowIndex = direction === 'downward' ? mod : sourceRowCount - 1 - mod;
+            const sourceRecordId = sourceRows[sourceRowIndex];
+            const sourceValue = recordsMap[sourceRecordId]?.values[fieldId];
+
+            updateData.push({
+                path: [targetRecordId, fieldId],
+                value: sourceValue
+            });
+        }
+    }
+
+    if (updateData.length > 0) {
+        actions.updateFieldValues(updateData);
+    }
+}
+
+export function getFillAreaBounds(selectedCells: Set<string>): { firstCell: AIRecordFieldIdPath; lastCell: AIRecordFieldIdPath } {
+    let firstCell: AIRecordFieldIdPath;
+    let lastCell: AIRecordFieldIdPath;
+
+    const selectedCellsArray = Array.from(selectedCells);
+    const startCell = selectedCellsArray[0].split(':');
+    const endCell = selectedCellsArray[selectedCellsArray.length - 1].split(':');
+    firstCell = [startCell[0], startCell[1]];
+    lastCell = [endCell[0], endCell[1]];
+
+    return { firstCell, lastCell };
+}

--- a/packages/grid/src/utils/drag-fill/index.ts
+++ b/packages/grid/src/utils/drag-fill/index.ts
@@ -1,0 +1,1 @@
+export * from './drag-fill';

--- a/packages/grid/src/utils/index.ts
+++ b/packages/grid/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from './clear-cells';
 export * from './i18n';
 export * from './file';
 export * from './transform';
+export * from './drag-fill';

--- a/packages/grid/src/utils/style.ts
+++ b/packages/grid/src/utils/style.ts
@@ -3,6 +3,7 @@ import {
     AI_TABLE_FIELD_HEAD_MORE,
     AI_TABLE_FIELD_HEAD_OPACITY_LINE,
     AI_TABLE_FIELD_HEAD_SELECT_CHECKBOX,
+    AI_TABLE_FILL_HANDLE,
     AI_TABLE_ROW_ADD_BUTTON,
     AI_TABLE_ROW_DRAG,
     AI_TABLE_ROW_SELECT_CHECKBOX
@@ -19,6 +20,7 @@ export const handleMouseStyle = (
     const { targetName, mouseStyle } = getDetailByTargetName(realTargetName);
     if (mouseStyle) return setMouseStyle(mouseStyle, container);
     if (areaType === AITableAreaType.none) return setMouseStyle('default', container);
+
     switch (targetName) {
         case AI_TABLE_FIELD_HEAD_SELECT_CHECKBOX:
         case AI_TABLE_FIELD_HEAD_MORE:
@@ -35,6 +37,9 @@ export const handleMouseStyle = (
         }
         case AI_TABLE_ROW_DRAG: {
             return setMouseStyle('pointer', container);
+        }
+        case AI_TABLE_FILL_HANDLE: {
+            return setMouseStyle('crosshair', container);
         }
 
         default:


### PR DESCRIPTION
填充逻辑：按照选中区域的行数作为周期进行填充。

向下填充：从源区域最后一行开始，按周期循环。 
示例：选中3行2列，向下填充时
- 第1、4、7、10...行的值相同（对应源区域第3行）
- 第2、5、8、11...行的值相同（对应源区域第2行）
- 第3、6、9、12...行的值相同（对应源区域第1行）

向上填充：从源区域最后一行开始，按倒序周期循环。
示例：选中3行2列，向上填充时
- 倒数第1、4、7、10...行的值相同（对应源区域倒数第1行）
- 倒数第2、5、8、11...行的值相同（对应源区域倒数第2行）
- 倒数第3、6、9、12...行的值相同（对应源区域倒数第3行）