### PR TITLE
fix(action): apply action by draft data #WIK-18976

### DIFF
--- a/packages/state/src/action/general.ts
+++ b/packages/state/src/action/general.ts
@@ -18,7 +18,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         case ActionName.UpdateFieldValue: {
             const [recordId, fieldId] = action.path;
             if (recordId && fieldId) {
-                const recordIndex = aiTable.records().findIndex((item) => item._id === recordId);
+                const recordIndex = records.findIndex((item) => item._id === recordId);
                 records[recordIndex].values[fieldId] = action.newFieldValue;
             }
             break;
@@ -26,7 +26,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         case ActionName.UpdateSystemFieldValue: {
             const [recordId] = action.path;
             if (recordId && action.updatedInfo) {
-                const recordIndex = aiTable.records().findIndex((item) => item._id === recordId);
+                const recordIndex = records.findIndex((item) => item._id === recordId);
                 if (action.updatedInfo.updated_at) {
                     records[recordIndex].updated_at = action.updatedInfo.updated_at;
                 }
@@ -51,7 +51,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         }
         case ActionName.RemoveField: {
             const [fieldId] = action.path;
-            const fieldIndex = aiTable.fields().findIndex((item) => item._id === fieldId);
+            const fieldIndex = fields.findIndex((item) => item._id === fieldId);
             if (fieldIndex > -1) {
                 fields.splice(fieldIndex, 1);
                 records.forEach((item) => {
@@ -62,7 +62,7 @@ const apply = (aiTable: AIViewTable, records: AITableViewRecords, fields: AITabl
         }
         case ActionName.RemoveRecord: {
             const [recordId] = action.path;
-            const recordIndex = aiTable.records().findIndex((item) => item._id === recordId);
+            const recordIndex = records.findIndex((item) => item._id === recordId);
             if (recordIndex > -1) {
                 records.splice(recordIndex, 1);
             }


### PR DESCRIPTION
This pull request will fix unexpect index issue on delete multiple records, use records get index instead of aiTable.records().

原始数据：
[
{id: a, ...},
{id: 2, ...},
{id: 3, ...},
{id: 4, ...},
{id: b, ...},
{id: c, ...},
{id: d, ...}
]
删除 2、3、4
原来的方法获取到的索引分别是 1、2、3
使用 records 删除时第一个删除的是 2 没错，第二个删除时基于的数据是：
[
{id: a, ...},
{id: 3, ...},
{id: 4, ...},
{id: b, ...},
{id: c, ...},
{id: d, ...}
]
而索引还是 2 ，最终删除的是 4
删除第三个时，
[
{id: a, ...},
{id: 3, ...},
{id: b, ...},
{id: c, ...},
{id: d, ...}
]
索引还是 3，最终删除的是 c
目前 rc 有同样的问题，应该是以前因为性能问题支持批量应用 actions 后就有问题 https://github.com/worktile/ai-table/pull/469/files