### PR TITLE
fix: #WIK-18981 【AITable】有筛选条件下，点击顶部的勾选所有，右键行，删除。 应该只删除用户看到的勾选行的删除，而不是删除整个表格的所有记录

### DIFF
--- a/packages/grid/src/utils/record.ts
+++ b/packages/grid/src/utils/record.ts
@@ -21,7 +21,7 @@ export function toggleSelectRecord(aiTable: AITable, recordId: string) {
 export function toggleSelectAllRecords(aiTable: AITable, checked: boolean) {
     if (checked) {
         setSelection(aiTable, {
-            selectedRecords: new Set(aiTable.records().map((item) => item._id))
+            selectedRecords: new Set(aiTable.gridData().records.map((item) => item._id))
         });
     } else {
         clearSelection(aiTable);


### PR DESCRIPTION
…是删除整个表格的所有记录