### PR TITLE
refactor(state): rename fieldStatTypes to stat_types #WIK-19193

### DIFF
--- a/packages/state/src/action/field.ts
+++ b/packages/state/src/action/field.ts
@@ -35,7 +35,7 @@ export function setFieldWidth(aiTable: AIViewTable, path: IdPath, width: number)
 
 export function setFieldStatType(aiTable: AIViewTable, path: IdPath, statType: AITableFieldStatType) {
     const field = AITableQueries.getField(aiTable, path) as AITableViewField;
-    setField(aiTable, { fieldStatTypes: { ...field.fieldStatTypes, [aiTable.activeViewId()]: statType } }, [field._id]);
+    setField(aiTable, { stat_types: { ...field.stat_types, [aiTable.activeViewId()]: statType } }, [field._id]);
 }
 
 export function removeField(aiTable: AIViewTable, path: IdPath) {

--- a/packages/state/src/utils/field/stat-field.ts
+++ b/packages/state/src/utils/field/stat-field.ts
@@ -2,7 +2,7 @@ import { AITableView, AITableViewFields } from '@ai-table/utils';
 
 export function buildFieldStatType(data: AITableViewFields, activeView: AITableView) {
     return data.map((field, index) => {
-        const fieldStatType = field.fieldStatTypes?.[activeView._id];
+        const fieldStatType = field.stat_types?.[activeView._id];
         if (fieldStatType) {
             return {
                 ...field,

--- a/packages/utils/src/types/view.ts
+++ b/packages/utils/src/types/view.ts
@@ -17,7 +17,7 @@ export interface AITableViewRecord extends AITableRecord {
 export interface AITableViewField extends AITableField {
     positions: Positions;
     widths?: Record<Id, number>;
-    fieldStatTypes?: Record<Id, AITableFieldStatType>;
+    stat_types?: Record<Id, AITableFieldStatType>;
 }
 
 export type AITableViewRecords = AITableViewRecord[];


### PR DESCRIPTION
```
export interface AITableField {
    _id: string;
    name: string;
    type: AITableFieldType | string;
    icon?: string;
    width?: number;
    hidden?: boolean;
    frozen?: boolean;
    stat_type?: AITableFieldStatType;
    settings?: AITableFieldSettings;
}

export interface AITableViewField extends AITableField {
    positions: Positions;
    widths?: Record<Id, number>; 
    fieldStatTypes?: Record<Id, AITableFieldStatType>;    ❌ 命名规范不一致
}

```