### PR TITLE
feat(state): support use ai-table-grid without views and add editable example

### DIFF
--- a/packages/state/src/action/general.ts
+++ b/packages/state/src/action/general.ts
@@ -153,7 +153,7 @@ export const GeneralActions = {
     transform(aiTable: AIViewTable, actions: AITableAction[]): void {
         const records = createDraft(aiTable.records()) as AITableViewRecords;
         const fields = createDraft(aiTable.fields()) as AITableViewFields;
-        const views = createDraft(aiTable.views());
+        const views = createDraft(aiTable.views?.() || []);
         actions.forEach((action) => {
             apply(aiTable, records, fields, views, action);
         });
@@ -166,8 +166,8 @@ export const GeneralActions = {
         if (newRecords !== aiTable.records()) {
             aiTable.records.set(newRecords);
         }
-        if (newViews !== aiTable.views()) {
-            aiTable.views.set(newViews);
+        if (newViews !== (aiTable.views?.() || [])) {
+            aiTable.views?.set(newViews);
         }
     }
 };

--- a/packages/state/src/utils/position-in-view.ts
+++ b/packages/state/src/utils/position-in-view.ts
@@ -11,7 +11,7 @@ export function findNextItemByPosition<T extends AITableViewRecord | AITableView
     items: T[],
     itemsMap: { [key: string]: T extends AITableViewRecord ? AITableRecord : AITableViewField }
 ): T | null {
-    const viewId = aiTable.activeViewId();
+    const viewId = aiTable.activeViewId?.();
     const targetItem = itemsMap[targetId] as T;
     const targetPosition = targetItem.positions[viewId] || 0;
     let nextItem: T | null = null;
@@ -25,11 +25,11 @@ export function findNextItemByPosition<T extends AITableViewRecord | AITableView
 }
 
 export function findMaxItemByPosition<T extends AITableViewRecord | AITableViewField>(aiTable: AIViewTable, items: T[]): T {
-    const viewId = aiTable.activeViewId();
+    const viewId = aiTable.activeViewId?.();
     let maxItem = items[0] as T;
     for (const item of items) {
-        const pos = item.positions[viewId] || 0;
-        if (pos > maxItem.positions[viewId]) {
+        const pos = item?.positions?.[viewId] || 0;
+        if (pos > maxItem?.positions?.[viewId]) {
             maxItem = item;
         }
     }
@@ -42,7 +42,7 @@ export function findPrevItemByPosition<T extends AITableViewRecord | AITableView
     items: T[],
     itemsMap: { [key: string]: T extends AITableViewRecord ? AITableRecord : AITableViewField }
 ): T | null {
-    const viewId = aiTable.activeViewId();
+    const viewId = aiTable.activeViewId?.();
     const targetItem = itemsMap[targetId] as T;
     const targetPosition = targetItem.positions[viewId] || 0;
     let prevItem: T | null = null;
@@ -61,7 +61,7 @@ export function getPreviousAndNextPosition<T extends AITableViewRecord | AITable
     items: T[],
     itemsMap: { [key: string]: T extends AITableViewRecord ? AITableRecord : AITableViewField }
 ): { nextPosition: number | null; previousPosition: number | null } {
-    const activeViewId = aiTable.activeViewId();
+    const activeViewId = aiTable.activeViewId?.();
     const { afterItemId, beforeItemId } = options;
     let nextPosition = null;
     let previousPosition = null;
@@ -71,10 +71,10 @@ export function getPreviousAndNextPosition<T extends AITableViewRecord | AITable
         if (!previousItem) {
             throw new Error(`Target item with id ${afterItemId} not found`);
         }
-        previousPosition = previousItem.positions[activeViewId] || 0;
+        previousPosition = previousItem?.positions?.[activeViewId] || 0;
         const nextItem = findNextItemByPosition<T>(aiTable, afterItemId, items, itemsMap);
         if (nextItem !== null) {
-            nextPosition = nextItem.positions[activeViewId] || 0;
+            nextPosition = nextItem?.positions?.[activeViewId] || 0;
         }
     } else if (beforeItemId) {
         const nextItem = itemsMap[beforeItemId] as T;
@@ -82,14 +82,14 @@ export function getPreviousAndNextPosition<T extends AITableViewRecord | AITable
             throw new Error(`Target item with id ${beforeItemId} not found`);
         }
 
-        nextPosition = nextItem.positions[activeViewId] || 0;
+        nextPosition = nextItem?.positions?.[activeViewId] || 0;
         const previousItem = findPrevItemByPosition<T>(aiTable, beforeItemId, items, itemsMap);
         if (previousItem !== null) {
-            previousPosition = previousItem.positions[activeViewId] || 0;
+            previousPosition = previousItem?.positions?.[activeViewId] || 0;
         }
     } else {
         const maxItem = findMaxItemByPosition<T>(aiTable, items);
-        previousPosition = maxItem.positions[activeViewId] || 0;
+        previousPosition = maxItem?.positions?.[activeViewId] || 0;
     }
     return {
         nextPosition,
@@ -136,8 +136,8 @@ export function getNewItemsPosition<T extends AITableViewRecord | AITableViewFie
     if (positions.length === 0) {
         return [];
     }
-    const views = aiTable.views();
-    const activeViewId = aiTable.activeViewId();
+    const views = aiTable.views?.() || [];
+    const activeViewId = aiTable.activeViewId?.();
     const viewsMaxPosition: Record<string, number> = {};
     views.forEach((view) => {
         viewsMaxPosition[view._id] = getMaxPosition(items as AITableViewRecords | AITableViewFields, view._id);

--- a/packages/state/src/utils/record/add-records.ts
+++ b/packages/state/src/utils/record/add-records.ts
@@ -3,15 +3,15 @@ import { AIViewTable } from '../../types';
 import { getSortFields } from '../field/sort-fields';
 import { Actions } from '../../action';
 import { checkConditions, getDefaultRecordDataByFilter } from './filter';
-import { AddRecordOptions, AITableRecord, AITableViewFields, FieldValue, TrackableEntity } from '@ai-table/utils';
+import { AddRecordOptions, AITableRecord, AITableViewFields, FieldValue, AITableRecordCreatedInfo } from '@ai-table/utils';
 import { getParentGroupValuesByGroupId, getPrevRecordIdByAddGroupId } from './common';
 
-export function addRecords(aiTable: AIViewTable, trackableEntity: TrackableEntity, options?: AddRecordOptions) {
+export function addRecords(aiTable: AIViewTable, options: AddRecordOptions, trackableEntity: AITableRecordCreatedInfo) {
     options = options || {};
     const newRecords: AITableRecord[] = [];
-    const activeViewId = aiTable.activeViewId();
-    const activeView = aiTable.viewsMap()[activeViewId];
-    const groups = activeView.settings?.groups;
+    const activeViewId = aiTable.activeViewId?.();
+    const activeView = aiTable.viewsMap?.()?.[activeViewId];
+    const groups = activeView?.settings?.groups;
     let { originId, isDuplicate, count = 1 } = options;
     const recordCount = aiTable.records().length;
     const maxRecordCount = aiTable.context?.maxRecords();
@@ -75,15 +75,23 @@ export function getDefaultRecordValues(aiTable: AIViewTable, isDuplicate = false
     if (isDuplicate && recordId) {
         newRecordValues = aiTable.recordsMap()[recordId].values;
     } else {
-        const activeView = aiTable.viewsMap()[aiTable.activeViewId()];
-        const fields = getSortFields(aiTable, aiTable.fields() as AITableViewFields, activeView);
+        let fields = aiTable.fields() as AITableViewFields;
+
+        const activeView = aiTable.viewsMap?.()?.[aiTable.activeViewId?.()];
+        if (activeView) {
+            fields = getSortFields(aiTable, fields, activeView);
+        }
+
         fields.map((field) => {
             const defaultValue = FieldModelMap[field.type].getDefaultValue();
             newRecordValues[field._id] = defaultValue;
         });
-        const { conditions, condition_logical } = activeView.settings || {};
-        if (conditions && conditions.length) {
-            newRecordValues = getDefaultRecordDataByFilter(newRecordValues, conditions, fields, condition_logical);
+
+        if (activeView) {
+            const { conditions, condition_logical } = activeView.settings || {};
+            if (conditions && conditions.length) {
+                newRecordValues = getDefaultRecordDataByFilter(newRecordValues, conditions, fields, condition_logical);
+            }
         }
     }
     return newRecordValues;

--- a/packages/state/src/utils/record/add-records.ts
+++ b/packages/state/src/utils/record/add-records.ts
@@ -6,7 +6,7 @@ import { checkConditions, getDefaultRecordDataByFilter } from './filter';
 import { AddRecordOptions, AITableRecord, AITableViewFields, FieldValue, AITableRecordCreatedInfo } from '@ai-table/utils';
 import { getParentGroupValuesByGroupId, getPrevRecordIdByAddGroupId } from './common';
 
-export function addRecords(aiTable: AIViewTable, options: AddRecordOptions, trackableEntity: AITableRecordCreatedInfo) {
+export function addRecords(aiTable: AIViewTable, options: AddRecordOptions, recordCreatedInfo: AITableRecordCreatedInfo) {
     options = options || {};
     const newRecords: AITableRecord[] = [];
     const activeViewId = aiTable.activeViewId?.();
@@ -38,7 +38,7 @@ export function addRecords(aiTable: AIViewTable, options: AddRecordOptions, trac
             _id: id,
             short_id: newRecordShortIds[index],
             values: newRecordValues,
-            ...trackableEntity
+            ...recordCreatedInfo
         };
         if (needCopyGroupValuesMap) {
             groups?.forEach((group) => {

--- a/packages/state/src/utils/record/filter.ts
+++ b/packages/state/src/utils/record/filter.ts
@@ -45,6 +45,11 @@ export function checkConditions(
     if (!record) {
         return false;
     }
+
+    if (!aiTable.activeViewId?.() || !aiTable.viewsMap?.()) {
+        return true;
+    }
+
     if (!filterConditions?.conditions) {
         const conditions = aiTable.viewsMap()[aiTable.activeViewId()].settings?.conditions;
         const conditionLogical = aiTable.viewsMap()[aiTable.activeViewId()].settings?.condition_logical;

--- a/packages/state/src/utils/record/update-field-value.ts
+++ b/packages/state/src/utils/record/update-field-value.ts
@@ -51,6 +51,10 @@ function updateWillMoveRecords(
     needUpdateOptions: UpdateFieldValueOptions<unknown>[],
     updatedInfo?: AITableRecordUpdatedInfo
 ) {
+    if (!aiTable.activeViewId?.() || !aiTable.viewsMap?.()) {
+        return;
+    }
+
     const activeView = aiTable.viewsMap()[aiTable.activeViewId()];
     const groups = activeView.settings?.groups ?? [];
     const sorts = activeView.settings?.sorts ?? [];

--- a/packages/utils/src/collaboration/utils.ts
+++ b/packages/utils/src/collaboration/utils.ts
@@ -17,7 +17,7 @@ import {
     SyncArrayElement,
     SyncMapElement,
     SystemFieldValues,
-    TrackableEntity,
+    AITableRecordCreatedInfo,
     TransactionOriginInfo
 } from '../types';
 import { AI_TABLE_CONTENT_FIELD_NAME, SystemFieldIndex } from '../constants';
@@ -178,7 +178,7 @@ export const getShortIdBySystemFieldValues = (systemFieldValues: SystemFieldValu
     return systemFieldValues[SystemFieldIndex.ShortId];
 };
 
-export const getTrackableEntityBySystemFieldValues = (systemFieldValues: SystemFieldValues): TrackableEntity => {
+export const getTrackableEntityBySystemFieldValues = (systemFieldValues: SystemFieldValues): AITableRecordCreatedInfo => {
     return {
         created_at: systemFieldValues[SystemFieldIndex.CreatedAt],
         created_by: systemFieldValues[SystemFieldIndex.CreatedBy],

--- a/packages/utils/src/types/core.ts
+++ b/packages/utils/src/types/core.ts
@@ -148,18 +148,6 @@ export type FieldValue =
     | CheckboxFieldValue
     | any;
 
-export interface TrackableEntity {
-    created_at: NumberFieldValue;
-    created_by: string;
-    updated_at: NumberFieldValue;
-    updated_by: string;
-}
-
-export interface UpdateTrackableEntity {
-    updated_at: NumberFieldValue;
-    updated_by: string;
-}
-
 export interface AITableRecord {
     _id: string;
     short_id: string;
@@ -171,8 +159,15 @@ export interface AITableRecord {
     [key: string]: any;
 }
 
+export interface AITableRecordCreatedInfo {
+    created_at: NumberFieldValue;
+    created_by: string;
+    updated_at: NumberFieldValue;
+    updated_by: string;
+}
+
 export interface AITableRecordUpdatedInfo {
-    updated_at: number;
+    updated_at: NumberFieldValue;
     updated_by: string;
 }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,7 @@
 <thy-menu class="menu">
     <a thyMenuItem href="javascript:;" [routerLink]="['/overall']" routerLinkActive="active"> Overall </a>
     <a thyMenuItem href="javascript:;" [routerLink]="['/basic']" routerLinkActive="active"> Basic </a>
+    <a thyMenuItem href="javascript:;" [routerLink]="['/editable']" routerLinkActive="active"> Editable </a>
 </thy-menu>
 <div cdkScrollable class="table-container">
     <router-outlet></router-outlet>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { DemoTableContent } from './component/common/content/content.component';
 import { DemoTable } from './component/table.component';
 import { TableBasicExample } from './examples/basic/basic.component';
+import { TableEditableExample } from './examples/editable/editable.component';
 
 export const routes: Routes = [
     {
@@ -22,5 +23,9 @@ export const routes: Routes = [
     {
         path: 'basic',
         component: TableBasicExample
+    },
+    {
+        path: 'editable',
+        component: TableEditableExample
     }
 ];

--- a/src/app/component/common/content/content.component.ts
+++ b/src/app/component/common/content/content.component.ts
@@ -502,12 +502,11 @@ export class DemoTableContent {
         this.setValue();
     }
 
-    addRecord(options?: AddRecordOptions) {
+    addRecord(options: AddRecordOptions) {
         console.log('addRecord', options);
         const member = 'member_01';
         const time = getUnixTime(new Date());
-        const trackableEntity = { created_by: member, created_at: time, updated_by: member, updated_at: time };
-        addRecords(this.aiTable, trackableEntity, options);
+        addRecords(this.aiTable, options, { created_by: member, created_at: time, updated_by: member, updated_at: time });
     }
 
     updateFieldValues(options: UpdateFieldValueOptions[]) {

--- a/src/app/examples/editable/editable.component.html
+++ b/src/app/examples/editable/editable.component.html
@@ -1,0 +1,13 @@
+<p>添加行、添加列、编辑单元格</p>
+
+<ai-table-grid
+    [(aiRecords)]="records"
+    [(aiFields)]="fields"
+    [aiReferences]="references()"
+    [aiPlugins]="plugins"
+    (aiTableInitialized)="aiTableInitialized($event)"
+    (aiAddRecord)="addRecord($event)"
+    (aiAddField)="addField($event)"
+    (aiUpdateFieldValues)="updateFieldValues($event)"
+>
+</ai-table-grid>

--- a/src/app/examples/editable/editable.component.ts
+++ b/src/app/examples/editable/editable.component.ts
@@ -1,0 +1,70 @@
+import { Component, signal } from '@angular/core';
+import { AITableGrid } from '@ai-table/grid';
+import {
+    AITable,
+    AITableRecord,
+    AITableField,
+    AITableReferences,
+    AddFieldOptions,
+    AddRecordOptions,
+    UpdateFieldValueOptions,
+    AITableRecordUpdatedInfo,
+    AITableRecordCreatedInfo
+} from '@ai-table/utils';
+import { AIViewTable, addFields, addRecords, updateFieldValues, withState } from '@ai-table/state';
+import { mockRecords, mockFields, mockReferences } from './mock';
+import { getUnixTime } from 'date-fns';
+import { ThyPopoverModule } from 'ngx-tethys/popover';
+
+@Component({
+    selector: 'app-table-editable-example',
+    templateUrl: './editable.component.html',
+    imports: [AITableGrid, ThyPopoverModule],
+    host: {
+        class: 'd-block w-100 h-100'
+    }
+})
+export class TableEditableExample {
+    fields = signal<AITableField[]>(mockFields);
+
+    records = signal<AITableRecord[]>(mockRecords);
+
+    references = signal<AITableReferences>(mockReferences);
+
+    aiTable!: AIViewTable;
+
+    plugins = [withState];
+
+    aiTableInitialized(aiTable: AITable) {
+        this.aiTable = aiTable as AIViewTable;
+        this.aiTable.onChange = () => {};
+    }
+
+    addField(fieldOptions: AddFieldOptions) {
+        addFields(this.aiTable, fieldOptions);
+    }
+
+    addRecord(recordOptions: AddRecordOptions) {
+        const mockMemberUID = Object.keys(mockReferences.members)[0];
+        const mockTime = getUnixTime(new Date());
+        const recordCreatedInfo: AITableRecordCreatedInfo = {
+            created_by: mockMemberUID,
+            created_at: mockTime,
+            updated_by: mockMemberUID,
+            updated_at: mockTime
+        };
+
+        addRecords(this.aiTable, recordOptions, recordCreatedInfo);
+    }
+
+    updateFieldValues(valueOptions: UpdateFieldValueOptions[]) {
+        const mockMemberUID = Object.keys(mockReferences.members)[0];
+        const mockTime = getUnixTime(new Date());
+        const recordUpdatedInfo: AITableRecordUpdatedInfo = {
+            updated_by: mockMemberUID,
+            updated_at: mockTime
+        };
+
+        updateFieldValues(this.aiTable, valueOptions, recordUpdatedInfo);
+    }
+}

--- a/src/app/examples/editable/mock.ts
+++ b/src/app/examples/editable/mock.ts
@@ -1,0 +1,81 @@
+import { AITableField, AITableFieldType, AITableRecord, AITableReferences, AITableSelectOptionStyle } from '@ai-table/utils';
+
+export const mockFields: AITableField[] = [
+    {
+        _id: 'fieldId_text',
+        name: '姓名',
+        type: AITableFieldType.text
+    },
+    {
+        _id: 'fieldId_number',
+        name: '年龄',
+        type: AITableFieldType.number
+    },
+    {
+        _id: 'fieldId_select',
+        name: '性别',
+        type: AITableFieldType.select,
+        settings: {
+            option_style: AITableSelectOptionStyle.dot,
+            options: [
+                {
+                    text: '男',
+                    _id: 'singleOptionId001',
+                    color: '#5dcfff'
+                },
+                {
+                    text: '女',
+                    _id: 'singleOptionId002',
+                    color: '#ffcd5d'
+                }
+            ]
+        }
+    }
+];
+
+export const mockRecords: AITableRecord[] = [
+    {
+        _id: 'recordId001',
+        short_id: 'recordShortId001',
+        created_at: 1760757010,
+        created_by: 'memberUID002',
+        updated_at: 1761650871,
+        updated_by: 'memberUID002',
+        values: {
+            fieldId_text: '小明',
+            fieldId_number: 19,
+            fieldId_select: ['singleOptionId001']
+        }
+    },
+    {
+        _id: 'recordId002',
+        short_id: 'recordShortId002',
+        created_at: 1760757010,
+        created_by: 'memberUID004',
+        updated_at: 1761650871,
+        updated_by: 'memberUID004',
+        values: {
+            fieldId_text: '小红',
+            fieldId_number: 18,
+            fieldId_select: ['singleOptionId002']
+        }
+    },
+    {
+        _id: 'recordId003',
+        short_id: 'recordShortId003',
+        created_at: 1760757010,
+        created_by: 'memberUID005',
+        updated_at: 1761650871,
+        updated_by: 'memberUID005',
+        values: {
+            fieldId_text: '小刚',
+            fieldId_number: 32,
+            fieldId_select: ['singleOptionId001']
+        }
+    }
+];
+
+export const mockReferences: AITableReferences = {
+    members: {},
+    attachments: {}
+};


### PR DESCRIPTION
1. 支持单纯的表格使用，补充 editable 示例
<img width="1137" height="452" alt="image" src="https://github.com/user-attachments/assets/6211ba43-1887-4a7f-9e64-d53eae2cf74d" />

2. UpdateTrackableEntity 和 AITableRecordUpdatedInfo 完全一样，重复，保留 AITableRecordUpdatedInfo
```
export interface AITableRecordUpdatedInfo {
    updated_at: NumberFieldValue;
    updated_by: string;
}
```
3. TrackableEntity 改名为 AITableRecordCreatedInfo ，和 AITableRecordUpdatedInfo 命名风格一致。
```
export interface AITableRecordCreatedInfo {
    created_at: NumberFieldValue;
    created_by: string;
    updated_at: NumberFieldValue;
    updated_by: string;
}
```
4. addRecords 函数的第二个参数和第三个参数调整顺序，和 updateFieldValues 函数的保持一致
```
addRecords(aiTable, AddRecordOptions, AITableRecordCreatedInfo);  // 第二个参数和第三个参数调整顺序后
updateFieldValues(aiTable, UpdateFieldValueOptions, AITableRecordUpdatedInfo)  // 不变
```