### PR TITLE
refactor: remove useless group funciton and add group example

### DIFF
--- a/packages/state/src/action/group.ts
+++ b/packages/state/src/action/group.ts
@@ -1,27 +1,5 @@
-import { ActionName, SetViewAction, AITableGroupField, SortDirection, ViewSettings } from '@ai-table/utils';
+import { ActionName, SetViewAction, ViewSettings } from '@ai-table/utils';
 import { AIViewTable } from '../types/ai-table';
-import { AI_TABLE_GROUP_MAX_LEVEL } from '@ai-table/grid';
-
-function setViewGroup(aiTable: AIViewTable, groups: AITableGroupField[] | null) {
-    const viewId = aiTable.activeViewId();
-    const view = aiTable.views().find((v) => v._id === viewId);
-    if (!view) return;
-
-    const currentSettings = view.settings || {};
-    const newSettings: ViewSettings = {
-        ...currentSettings,
-        groups: groups || [],
-        collapsed_group_ids: [] // 重置折叠
-    };
-
-    const operation: SetViewAction = {
-        type: ActionName.SetView,
-        properties: { settings: currentSettings },
-        newProperties: { settings: newSettings },
-        path: [viewId]
-    };
-    aiTable.apply(operation);
-}
 
 function setCollapsedGroup(aiTable: AIViewTable, collapsedGroupIds: string[]) {
     const viewId = aiTable.activeViewId();
@@ -43,7 +21,6 @@ function setCollapsedGroup(aiTable: AIViewTable, collapsedGroupIds: string[]) {
     aiTable.apply(operation);
 }
 
-// 折叠
 function toggleGroupCollapse(aiTable: AIViewTable, groupId: string) {
     const activeView = aiTable.viewsMap()[aiTable.activeViewId()];
     if (!activeView) return;
@@ -53,79 +30,6 @@ function toggleGroupCollapse(aiTable: AIViewTable, groupId: string) {
     setCollapsedGroup(aiTable, newCollapse);
 }
 
-// 添加分组
-function addGroupField(aiTable: AIViewTable, fieldId: string, direction: SortDirection = SortDirection.ascending) {
-    const activeView = aiTable.viewsMap()[aiTable.activeViewId()];
-    if (!activeView) return;
-
-    const currentGroups = activeView.settings?.groups || [];
-
-    // 是否已存在
-    if (currentGroups.some((group) => group.field_id === fieldId)) {
-        throw new Error('The field has been used for grouping.');
-    }
-
-    // 层级限制
-    if (currentGroups.length >= AI_TABLE_GROUP_MAX_LEVEL) {
-        throw new Error(`The maximum number of groups is ${AI_TABLE_GROUP_MAX_LEVEL}.`);
-    }
-
-    const newGroups: AITableGroupField[] = [...currentGroups, { field_id: fieldId, direction }];
-    setViewGroup(aiTable, newGroups);
-}
-
-// 删除分组
-function removeGroupField(aiTable: AIViewTable, fieldId: string) {
-    const view = aiTable.views().find((v) => v._id === aiTable.activeViewId());
-    if (!view) return;
-
-    const currentGroups = view.settings?.groups || [];
-    const newGroups = currentGroups.filter((group) => group.field_id !== fieldId);
-
-    setViewGroup(aiTable, newGroups.length > 0 ? newGroups : null);
-}
-
-// 更新排序方向
-function updateGroupFieldDirection(aiTable: AIViewTable, fieldId: string, direction: SortDirection) {
-    const view = aiTable.views().find((v) => v._id === aiTable.activeViewId());
-    if (!view) return;
-
-    const currentGroups = view.settings?.groups || [];
-    const newGroups = currentGroups.map((group) => (group.field_id === fieldId ? { ...group, direction } : group));
-
-    setViewGroup(aiTable, newGroups);
-}
-
-// 重新排序，拖拽顺序
-function reorderGroupFields(aiTable: AIViewTable, fromIndex: number, toIndex: number) {
-    const view = aiTable.views().find((v) => v._id === aiTable.activeViewId());
-    if (!view) return;
-
-    const currentGroups = view.settings?.groups || [];
-
-    if (fromIndex < 0 || fromIndex >= currentGroups.length || toIndex < 0 || toIndex >= currentGroups.length) {
-        return;
-    }
-
-    const newGroups = [...currentGroups];
-    const [movedItem] = newGroups.splice(fromIndex, 1);
-    newGroups.splice(toIndex, 0, movedItem);
-
-    setViewGroup(aiTable, newGroups);
-}
-
-// 清空分组
-function clearAllGroups(aiTable: AIViewTable) {
-    setViewGroup(aiTable, null);
-}
-
 export const GroupActions = {
-    setViewGroup,
-    setCollapsedGroup,
-    toggleGroupCollapse,
-    addGroupField,
-    removeGroupField,
-    updateGroupFieldDirection,
-    reorderGroupFields,
-    clearAllGroups
+    toggleGroupCollapse
 };

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
     <a thyMenuItem href="javascript:;" [routerLink]="['/view']" routerLinkActive="active"> View </a>
     <a class="ml-4" thyMenuItem href="javascript:;" [routerLink]="['/group']" routerLinkActive="active"> Group </a>
     <a class="ml-4" thyMenuItem href="javascript:;" [routerLink]="['/filter']" routerLinkActive="active"> Filter </a>
-    <a class="ml-4" thyMenuItem href="javascript:;" [routerLink]="['/sort']" routerLinkActive="active"> Sort </a>
+    <a class="ml-4" thyMenuItem href="javascript:;" [routerLink]="['/sort-records']" routerLinkActive="active"> Sort Records</a>
     <a class="ml-4" thyMenuItem href="javascript:;" [routerLink]="['/record-height']" routerLinkActive="active"> Record Height </a>
 </thy-menu>
 <div cdkScrollable class="table-container">

--- a/src/app/examples/group/group.component.html
+++ b/src/app/examples/group/group.component.html
@@ -1,1 +1,24 @@
 <p>分组</p>
+
+<app-combination-sort-example
+    class="d-block mb-4"
+    [title]="'分组'"
+    [placeholder]="'选择一列进行分组'"
+    [fields]="fields()"
+    [sorts]="groups()"
+    [isKeepSort]="true"
+    [icon]="'group-setup'"
+    [limitCount]="3"
+    (sortChange)="groupsChange($event)"
+></app-combination-sort-example>
+
+<ai-table-grid
+    [(aiRecords)]="records"
+    [(aiFields)]="fields"
+    [aiReferences]="references()"
+    [aiPlugins]="plugins"
+    [aiBuildGroupLinearRowsFn]="buildGroupLinearRowsFn()"
+    (aiTableInitialized)="aiTableInitialized($event)"
+    (aiRowGroupCollapseClick)="toggleGroupCollapse($event)"
+>
+</ai-table-grid>

--- a/src/app/examples/group/group.component.ts
+++ b/src/app/examples/group/group.component.ts
@@ -1,7 +1,104 @@
-import { Component } from '@angular/core';
+import {
+    AITableField,
+    AITableReferences,
+    AITable,
+    AITableRecord,
+    AITableViewRecord,
+    AITableSort,
+    AITableGroupField,
+    ViewSettings
+} from '@ai-table/utils';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { mockFields, mockRecords, mockReferences, mockViews } from './mock';
+import { AIViewTable, withState, Actions, buildLinearRows } from '@ai-table/state';
+import { CombinationSortExample } from '../common';
+import { AITableGrid, AITableLinearRow } from '@ai-table/grid';
+import { ViewService } from '../view/views';
+import { helpers } from 'ngx-tethys/util';
+import * as _ from 'lodash';
 
 @Component({
     selector: 'app-table-group-example',
-    templateUrl: './group.component.html'
+    templateUrl: './group.component.html',
+    imports: [AITableGrid, CombinationSortExample],
+    providers: [ViewService]
 })
-export class TableGroupExample {}
+export class TableGroupExample {
+    aiTable!: AIViewTable;
+
+    fields = signal<AITableField[]>(mockFields);
+
+    records = signal<AITableRecord[]>(mockRecords);
+
+    references = signal<AITableReferences>(mockReferences);
+
+    plugins = [withState];
+
+    private viewService = inject(ViewService);
+
+    readonly groups = computed<AITableSort[]>(() => {
+        return (this.viewService.activeView()?.settings?.groups || []).map((group: AITableGroupField) => ({
+            sort_by: group.field_id,
+            direction: group.direction
+        }));
+    });
+
+    readonly buildGroupLinearRowsFn: Signal<() => AITableLinearRow[] | null> = computed(() => {
+        return () => {
+            const activeView = this.viewService.activeView();
+            const hasGroups = activeView?.settings?.groups?.length;
+            if (hasGroups) {
+                return buildLinearRows(this.aiTable, activeView, this.records() as AITableViewRecord[]);
+            }
+            return null;
+        };
+    });
+
+    aiTableInitialized(aiTable: AITable) {
+        this.aiTable = aiTable as AIViewTable;
+        this.aiTable.onChange = () => {};
+
+        this.aiTable.activeViewId = this.viewService.activeViewId;
+        this.aiTable.views = this.viewService.views;
+        this.aiTable.viewsMap = computed(() => {
+            return helpers.keyBy(this.viewService.views(), '_id');
+        });
+
+        this.viewService.setViews(mockViews);
+        this.viewService.setActiveView(mockViews[0]._id);
+    }
+
+    groupsChange(event: { sorts: AITableSort[] }) {
+        const newGroups: AITableGroupField[] = event.sorts.map((sort) => {
+            return {
+                field_id: sort.sort_by,
+                direction: sort.direction
+            };
+        });
+        const settings = this.viewService.activeView().settings;
+        const oldGroups = settings?.groups || [];
+
+        if (!_.isEqual(newGroups, oldGroups)) {
+            // update groups in view settings
+            const newSettings: ViewSettings = {
+                ...(this.viewService.activeView()?.settings || {}),
+                groups: newGroups
+            };
+
+            // update collapsed_group_ids in view settings, should remove the deleted groups from collapsed_group_ids
+            const collapsedGroupIds = settings?.collapsed_group_ids || [];
+            const deletedGroups = _.differenceBy(oldGroups, newGroups, 'field_id');
+            if (deletedGroups.length > 0) {
+                const newCollapsedGroupIds = collapsedGroupIds.filter((id) => !deletedGroups.some((group) => id.includes(group.field_id)));
+                newSettings.collapsed_group_ids = newCollapsedGroupIds;
+            }
+
+            Actions.setView(this.aiTable, { settings: newSettings }, [this.viewService.activeViewId()]);
+        }
+    }
+
+    toggleGroupCollapse(groupId: string) {
+        // update collapsed_group_ids in view settings
+        Actions.toggleGroupCollapse(this.aiTable, groupId);
+    }
+}

--- a/src/app/examples/group/mock.ts
+++ b/src/app/examples/group/mock.ts
@@ -1,0 +1,150 @@
+import {
+    AITableRecord,
+    AITableField,
+    AITableReferences,
+    AITableSelectOptionStyle,
+    AITableView,
+    AITableFieldType,
+    SortDirection
+} from '@ai-table/utils';
+
+export const mockViews: AITableView[] = [
+    {
+        _id: 'viewId001',
+        short_id: 'viewShortId001',
+        name: '表格视图',
+        settings: {
+            // Look：group settings save here
+            groups: [{ field_id: 'fieldId_select', direction: SortDirection.ascending }],
+            collapsed_group_ids: ['fieldId_select_0_0'] //  The format of groupId is `${fieldId}_${depth}_${breakpointIndex}`;
+        }
+    },
+    {
+        _id: 'viewId002',
+        short_id: 'viewShortId002',
+        name: '表格视图 2',
+        settings: {
+            groups: [],
+            collapsed_group_ids: []
+        }
+    }
+];
+
+export const mockFields: AITableField[] = [
+    {
+        _id: 'fieldId_text',
+        name: '名称',
+        type: AITableFieldType.text
+    },
+    {
+        _id: 'fieldId_number',
+        name: '单价',
+        type: AITableFieldType.number
+    },
+    {
+        _id: 'fieldId_select',
+        name: '类别',
+        type: AITableFieldType.select,
+        settings: {
+            option_style: AITableSelectOptionStyle.piece,
+            options: [
+                {
+                    text: '蔬菜',
+                    _id: 'singleOptionId001',
+                    color: '#5dcfff'
+                },
+                {
+                    text: '水果',
+                    _id: 'singleOptionId002',
+                    color: '#ffcd5d'
+                }
+            ]
+        }
+    }
+];
+
+export const mockRecords: AITableRecord[] = [
+    {
+        _id: 'recordId001',
+        short_id: 'recordShortId001',
+        created_at: 1760757010,
+        created_by: 'memberUID002',
+        updated_at: 1761650871,
+        updated_by: 'memberUID002',
+        values: {
+            fieldId_text: '玉米',
+            fieldId_number: 2,
+            fieldId_select: ['singleOptionId001']
+        }
+    },
+    {
+        _id: 'recordId002',
+        short_id: 'recordShortId002',
+        created_at: 1760757010,
+        created_by: 'memberUID004',
+        updated_at: 1761650871,
+        updated_by: 'memberUID004',
+        values: {
+            fieldId_text: '西红柿',
+            fieldId_number: 3,
+            fieldId_select: ['singleOptionId001']
+        }
+    },
+    {
+        _id: 'recordId003',
+        short_id: 'recordShortId003',
+        created_at: 1760757010,
+        created_by: 'memberUID005',
+        updated_at: 1761650871,
+        updated_by: 'memberUID005',
+        values: {
+            fieldId_text: '香菜',
+            fieldId_number: 1,
+            fieldId_select: ['singleOptionId001']
+        }
+    },
+    {
+        _id: 'recordId004',
+        short_id: 'recordShortId004',
+        created_at: 1760757010,
+        created_by: 'memberUID006',
+        updated_at: 1761650871,
+        updated_by: 'memberUID006',
+        values: {
+            fieldId_text: '苹果',
+            fieldId_number: 5,
+            fieldId_select: ['singleOptionId002']
+        }
+    },
+    {
+        _id: 'recordId005',
+        short_id: 'recordShortId005',
+        created_at: 1760757010,
+        created_by: 'memberUID007',
+        updated_at: 1761650871,
+        updated_by: 'memberUID007',
+        values: {
+            fieldId_text: '香蕉',
+            fieldId_number: 2,
+            fieldId_select: ['singleOptionId002']
+        }
+    },
+    {
+        _id: 'recordId006',
+        short_id: 'recordShortId006',
+        created_at: 1760757010,
+        created_by: 'memberUID008',
+        updated_at: 1761650871,
+        updated_by: 'memberUID008',
+        values: {
+            fieldId_text: '葡萄',
+            fieldId_number: 6,
+            fieldId_select: ['singleOptionId002']
+        }
+    }
+];
+
+export const mockReferences: AITableReferences = {
+    members: {},
+    attachments: {}
+};

--- a/src/app/examples/sort-records/sort-records.component.html
+++ b/src/app/examples/sort-records/sort-records.component.html
@@ -15,7 +15,7 @@
     [aiReferences]="references()"
     [aiPlugins]="plugins"
     [aiFieldConfig]="fieldConfig()"
-    [aiBuildRenderDataFn]="aiBuildRenderDataFn()"
+    [aiBuildRenderDataFn]="buildRenderDataFn()"
     (aiTableInitialized)="aiTableInitialized($event)"
     (aiMoveRecords)="dragMoveRecords($event)"
 >

--- a/src/app/examples/sort-records/sort-records.component.ts
+++ b/src/app/examples/sort-records/sort-records.component.ts
@@ -62,7 +62,7 @@ export class TableSortRecordsExample {
         };
     });
 
-    readonly aiBuildRenderDataFn: Signal<() => AITableValue> = computed(() => {
+    readonly buildRenderDataFn: Signal<() => AITableValue> = computed(() => {
         return () => {
             const renderRecords = buildRecordsByView(
                 this.aiTable,


### PR DESCRIPTION
说明：group.ts 中有些函数没有使用场景，先删除。
目前：view.settings 的维护，有的地方调 Actions.setView 实现 ，有些地方弄单独Action，有些乱。 已经记任务后续优化

<img width="984" height="521" alt="image" src="https://github.com/user-attachments/assets/228f6134-c8fe-4286-b732-4083501f8c23" />
