### PR TITLE
fix: #WIK-19337 有分组的情况下，修改单元格内容（单选），界面直接刷新了，未提示位置变动

### DIFF
--- a/packages/grid/src/grid.component.ts
+++ b/packages/grid/src/grid.component.ts
@@ -848,8 +848,6 @@ export class AITableGrid extends AITableGridBase implements OnInit, OnDestroy {
         const fieldType = field.type;
         if (DBL_CLICK_EDIT_TYPE.includes(fieldType as AITableFieldType)) {
             setTimeout(() => {
-                // 边框重叠，清除选区
-                clearSelection(this.aiTable);
                 this.aiTableGridEventService.openCellEditor(this.aiTable, {
                     viewContainerRef: this.viewContainerRef,
                     container: this.containerElement(),

--- a/packages/grid/src/renderer/creations/create-active-cell-border.ts
+++ b/packages/grid/src/renderer/creations/create-active-cell-border.ts
@@ -63,16 +63,20 @@ export const createActiveCellBorder = (config: AITableCellsConfig) => {
                     offset += AI_TABLE_FIELD_HEAD_ICON_GAP_SIZE;
                 }
 
-                const currentConfig = {
-                    x: x + offset + AI_TABLE_OFFSET,
-                    y: y + AI_TABLE_OFFSET,
-                    width: width - AI_TABLE_CELL_BORDER / 2,
-                    height: rowHeight - AI_TABLE_CELL_BORDER / 2,
-                    strokeWidth: AI_TABLE_CELL_BORDER,
-                    stroke: colors.primary,
-                    fillEnabled: false,
-                    listening: false
-                };
+                let currentConfig: RectConfig | null = null;
+
+                if (!aiTable.editingCell()?.path) {
+                    currentConfig = {
+                        x: x + offset + AI_TABLE_OFFSET,
+                        y: y + AI_TABLE_OFFSET,
+                        width: width - AI_TABLE_CELL_BORDER / 2,
+                        height: rowHeight - AI_TABLE_CELL_BORDER / 2,
+                        strokeWidth: AI_TABLE_CELL_BORDER,
+                        stroke: colors.primary,
+                        fillEnabled: false,
+                        listening: false
+                    };
+                }
 
                 if (isFrozenColumn) {
                     frozenActiveCellBorder = currentConfig;

--- a/packages/grid/src/renderer/drawers/drawer.ts
+++ b/packages/grid/src/renderer/drawers/drawer.ts
@@ -406,7 +406,6 @@ export class Drawer {
                     });
                 }
             });
-            this.ctx.restore();
         };
 
         if (fillStyle) this.setStyle({ fillStyle });


### PR DESCRIPTION
问题原因，原来改的缺陷（双击进入编辑后，出现边框重复的问题），在进入编辑前执行了clearSelection，去除了active状态，来实现canvas不再渲染边框，导致  当前的bug。
修复逻辑：
1. 生成cell的border时增加判断，只有在cell状态 active 但不是 editing 的状态才渲染border.
2. 去除  this.ctx.restore();  这一块影响了除第一个文本cell 渲染外之后的文本渲染。